### PR TITLE
Makefile: Ensure built libs are removed in `clean`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,7 @@ libifupdown.a: ${LIBIFUPDOWN_OBJ}
 
 clean:
 	rm -f ${LIBIFUPDOWN_OBJ} ${CMD_OBJ}
+	rm -f ${LIBIFUPDOWN_LIB}
 	rm -f ${CMDS} ${MULTICALL}
 	rm -f ${MANPAGES}
 


### PR DESCRIPTION
This commit ensures that `${LIBIFUPDOWN_LIB}` is removed when `make
clean` is run.