### PR TITLE
add manpage xref to applet help output

### DIFF
--- a/cmd/ifquery.c
+++ b/cmd/ifquery.c
@@ -329,5 +329,6 @@ struct if_applet ifquery_applet = {
 	.desc = "query interface configuration",
 	.main = ifquery_main,
 	.usage = "ifquery [options] <interfaces>\n  ifquery [options] --list",
+	.manpage = "8 ifquery",
 	.groups = { &global_option_group, &match_option_group, &exec_option_group, &local_option_group },
 };

--- a/cmd/ifupdown.c
+++ b/cmd/ifupdown.c
@@ -239,6 +239,7 @@ struct if_applet ifup_applet = {
 	.desc = "bring interfaces up",
 	.main = ifupdown_main,
 	.usage = "ifup [options] <interfaces>",
+	.manpage = "8 ifup",
 	.groups = { &global_option_group, &match_option_group, &exec_option_group, },
 };
 
@@ -247,5 +248,6 @@ struct if_applet ifdown_applet = {
 	.desc = "take interfaces down",
 	.main = ifupdown_main,
 	.usage = "ifdown [options] <interfaces>",
+	.manpage = "8 ifdown",
 	.groups = { &global_option_group, &match_option_group, &exec_option_group, },
 };

--- a/cmd/multicall-options.c
+++ b/cmd/multicall-options.c
@@ -62,6 +62,9 @@ generic_usage(const struct if_applet *applet, int result)
 		}
 	}
 
+	if (applet->manpage != NULL)
+		fprintf(stderr, "\nFor more information: man %s\n", applet->manpage);
+
 	exit(result);
 }
 

--- a/cmd/multicall.h
+++ b/cmd/multicall.h
@@ -43,6 +43,7 @@ struct if_applet {
 	const char *name;
 	const char *desc;
 	const char *usage;
+	const char *manpage;
 	int (*const main)(int argc, char *argv[]);
 	const struct if_option_group *groups[16];
 };


### PR DESCRIPTION
These commits add an informative message advising people to check the manpage for more information, for example:

```
For more information: man 8 ifup
```