### PR TITLE
add compatibility with problematic ifupdown2 terms

### DIFF
--- a/cmd/multicall.h
+++ b/cmd/multicall.h
@@ -20,8 +20,6 @@
 
 #include "libifupdown/libifupdown.h"
 
-#define ARRAY_SIZE(x)   (sizeof(x) / sizeof(*x))
-
 struct if_applet;
 
 struct if_option {

--- a/libifupdown/libifupdown.h
+++ b/libifupdown/libifupdown.h
@@ -28,4 +28,8 @@
 #include "libifupdown/lifecycle.h"
 #include "libifupdown/tokenize.h"
 
+#ifndef ARRAY_SIZE
+# define ARRAY_SIZE(x)   (sizeof(x) / sizeof(*x))
+#endif
+
 #endif

--- a/tests/fixtures/vrf-ifupdown2.interfaces
+++ b/tests/fixtures/vrf-ifupdown2.interfaces
@@ -1,0 +1,7 @@
+iface vrf-red
+    vrf-table 1
+
+auto eth0
+iface eth0
+    use dhcp
+    vrf vrf-red

--- a/tests/ifquery_test
+++ b/tests/ifquery_test
@@ -19,7 +19,9 @@ tests_init \
 	inheritance_0 \
 	inheritance_1 \
 	implicit_vlan \
-	vrf_dependency
+	vrf_dependency \
+	vrf_ifupdown2_rewrite \
+	vrf_ifupdown2_dependency
 
 noargs_body() {
 	atf_check -s exit:1 -e ignore ifquery -S/dev/null
@@ -117,4 +119,14 @@ implicit_vlan_body() {
 vrf_dependency_body() {
 	atf_check -s exit:0 -o match:"requires vrf-red" \
 		ifquery -E $EXECUTORS_LINUX -i $FIXTURES/vrf.interfaces eth0
+}
+
+vrf_ifupdown2_rewrite_body() {
+	atf_check -s exit:0 -o match:"vrf-member vrf-red" \
+		ifquery -E $EXECUTORS -i $FIXTURES/vrf-ifupdown2.interfaces eth0
+}
+
+vrf_ifupdown2_dependency_body() {
+	atf_check -s exit:0 -o match:"requires vrf-red" \
+		ifquery -E $EXECUTORS_LINUX -i $FIXTURES/vrf-ifupdown2.interfaces eth0
 }


### PR DESCRIPTION
Some terms used by ifupdown2 do not trigger our implicit use system, and so we have other terms for those.

Right now, this is primarily `vrf` -> `vrf-member`, but the framework allows for adding other definitions.

Also, add a fixture and tests for ifupdown2 vrf configuration.