### PR TITLE
gre executor

### DIFF
--- a/executor-scripts/linux/gre
+++ b/executor-scripts/linux/gre
@@ -4,7 +4,7 @@
 
 [ -z "$IF_GRE_LOCAL" ] && exit 1
 [ -z "$IF_GRE_REMOTE" ] && exit 1
-[ -z "$IF_GRE_MODE" ] && exit 1
+[ -z "$IF_GRE_MODE" ] && IF_GRE_MODE="gre"
 
 COMMAND="link"
 FAMILY="-4"
@@ -24,6 +24,6 @@ post-down)
 	${MOCK} ip $FAMILY $COMMAND del $IFACE
 	;;
 depend)
-	echo "$IF_TUNNEL_DEV"
+	echo "$IF_GRE_DEV"
 	;;
 esac

--- a/executor-scripts/linux/gre
+++ b/executor-scripts/linux/gre
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+# Executor for advanced GRE tunnel management.
+
+[ -z "$IF_GRE_LOCAL" ] && exit 1
+[ -z "$IF_GRE_REMOTE" ] && exit 1
+[ -z "$IF_GRE_MODE" ] && exit 1
+
+COMMAND="link"
+FAMILY="-4"
+[ "$IF_GRE_MODE" = "ip6gre" ] && FAMILY="-6"
+
+PARAMS="mode $IF_GRE_MODE local '$IF_GRE_LOCAL' remote '$IF_GRE_REMOTE'"
+[ -n "$IF_GRE_TTL" ] && PARAMS="$PARAMS ttl '$IF_GRE_TTL'"
+[ -n "$IF_GRE_FLAGS" ] && PARAMS="$PARAMS $IF_GRE_FLAGS"
+
+[ -n "$PARAMS" ] || exit 0
+
+case "$PHASE" in
+pre-up)
+	${MOCK} eval ip $FAMILY $COMMAND add $IFACE $PARAMS
+	;;
+post-down)
+	${MOCK} ip $FAMILY $COMMAND del $IFACE
+	;;
+depend)
+	echo "$IF_TUNNEL_DEV"
+	;;
+esac

--- a/tests/fixtures/gre.interfaces
+++ b/tests/fixtures/gre.interfaces
@@ -1,0 +1,12 @@
+auto tun0
+iface tun0
+	gre-local 203.0.113.2
+	gre-remote 203.0.113.1
+	gre-dev eth0
+	gre-ttl 255
+	gre-flags nopmtudisc ignore-df
+	address 203.0.113.10/30
+	gateway 203.0.113.9
+
+iface eth0
+	address 203.0.113.2/30

--- a/tests/ifquery_test
+++ b/tests/ifquery_test
@@ -28,7 +28,8 @@ tests_init \
 	tunnel_legacy_dependency \
 	tunnel_legacy_rewrite \
 	tunnel_ifupdown2_dependency \
-	tunnel_ifupdown2_rewrite
+	tunnel_ifupdown2_rewrite \
+	gre_dependency
 
 noargs_body() {
 	atf_check -s exit:1 -e ignore ifquery -S/dev/null
@@ -179,4 +180,9 @@ tunnel_ifupdown2_rewrite_body() {
 		-o match:"tunnel-mode gre" \
 		-o match:"tunnel-ttl 255" \
 		ifquery -E $EXECUTORS_LINUX -i $FIXTURES/tunnel-ifupdown2.interfaces tun0
+}
+
+gre_dependency_body() {
+	atf_check -s exit:0 -o match:"requires eth0" \
+		ifquery -E $EXECUTORS_LINUX -i $FIXTURES/gre.interfaces tun0
 }

--- a/tests/linux/Kyuafile
+++ b/tests/linux/Kyuafile
@@ -9,3 +9,4 @@ atf_test_program{name='static_test'}
 atf_test_program{name='vrf_test'}
 atf_test_program{name='ppp_test'}
 atf_test_program{name='tunnel_test'}
+atf_test_program{name='gre_test'}

--- a/tests/linux/gre_test
+++ b/tests/linux/gre_test
@@ -1,0 +1,45 @@
+#!/usr/bin/env atf-sh
+
+. $(atf_get_srcdir)/../test_env.sh
+EXECUTOR="$(atf_get_srcdir)/../../executor-scripts/linux/gre"
+
+tests_init \
+	basic_bringup \
+	basic_teardown \
+	flags_bringup
+
+basic_bringup_body() {
+	export MOCK=echo IFACE=tun0 PHASE=pre-up \
+		IF_GRE_LOCAL=1.2.3.4 IF_GRE_REMOTE=5.6.7.8 \
+		IF_GRE_TTL=255
+	atf_check -s exit:0 \
+		-o match:"ip -4 link add tun0" \
+		-o match:"mode gre" \
+		-o match:"ttl '255'" \
+		-o match:"local '1.2.3.4'" \
+		-o match:"remote '5.6.7.8'" \
+		${EXECUTOR}
+}
+
+basic_teardown_body() {
+	export MOCK=echo IFACE=tun0 PHASE=post-down \
+		IF_GRE_LOCAL=1.2.3.4 IF_GRE_REMOTE=5.6.7.8 \
+		IF_GRE_TTL=255
+	atf_check -s exit:0 \
+		-o match:"ip -4 link del tun0" \
+		${EXECUTOR}
+}
+
+flags_bringup_body() {
+	export MOCK=echo IFACE=tun0 PHASE=pre-up \
+		IF_GRE_LOCAL=1.2.3.4 IF_GRE_REMOTE=5.6.7.8 \
+		IF_GRE_TTL=255 IF_GRE_FLAGS="nopmtudisc ignore-df"
+	atf_check -s exit:0 \
+		-o match:"ip -4 link add tun0" \
+		-o match:"mode gre" \
+		-o match:"ttl '255'" \
+		-o match:"local '1.2.3.4'" \
+		-o match:"remote '5.6.7.8'" \
+		-o match:"nopmtudisc ignore-df" \
+		${EXECUTOR}
+}


### PR DESCRIPTION
This is an executor that allows for advanced GRE tunnel configuration using ip-link(8).  iproute2 is required to make use of this executor, it will not work with busybox.

Closes #26.