### PR TITLE
execute: note the phase each executor is being invoked in

### DIFF
--- a/libifupdown/execute.c
+++ b/libifupdown/execute.c
@@ -140,10 +140,10 @@ lif_file_is_executable(const char *path)
 }
 
 bool
-lif_maybe_run_executor(const struct lif_execute_opts *opts, char *const envp[], const char *executor)
+lif_maybe_run_executor(const struct lif_execute_opts *opts, char *const envp[], const char *executor, const char *phase)
 {
 	if (opts->verbose)
-		fprintf(stderr, "ifupdown: attempting to run %s executor\n", executor);
+		fprintf(stderr, "ifupdown: attempting to run %s executor for phase %s\n", executor, phase);
 
 	char pathbuf[4096];
 
@@ -156,10 +156,10 @@ lif_maybe_run_executor(const struct lif_execute_opts *opts, char *const envp[], 
 }
 
 bool
-lif_maybe_run_executor_with_result(const struct lif_execute_opts *opts, char *const envp[], const char *executor, char *buf, size_t bufsize)
+lif_maybe_run_executor_with_result(const struct lif_execute_opts *opts, char *const envp[], const char *executor, char *buf, size_t bufsize, const char *phase)
 {
 	if (opts->verbose)
-		fprintf(stderr, "ifupdown: attempting to run %s executor\n", executor);
+		fprintf(stderr, "ifupdown: attempting to run %s executor for phase %s\n", executor, phase);
 
 	char pathbuf[4096];
 

--- a/libifupdown/execute.h
+++ b/libifupdown/execute.h
@@ -31,7 +31,7 @@ struct lif_execute_opts {
 extern bool lif_execute_fmt(const struct lif_execute_opts *opts, char *const envp[], const char *fmt, ...);
 extern bool lif_execute_fmt_with_result(const struct lif_execute_opts *opts, char *buf, size_t bufsize, char *const envp[], const char *fmt, ...);
 extern bool lif_file_is_executable(const char *path);
-extern bool lif_maybe_run_executor(const struct lif_execute_opts *opts, char *const envp[], const char *executor);
-extern bool lif_maybe_run_executor_with_result(const struct lif_execute_opts *opts, char *const envp[], const char *executor, char *buf, size_t bufsize);
+extern bool lif_maybe_run_executor(const struct lif_execute_opts *opts, char *const envp[], const char *executor, const char *phase);
+extern bool lif_maybe_run_executor_with_result(const struct lif_execute_opts *opts, char *const envp[], const char *executor, char *buf, size_t bufsize, const char *phase);
 
 #endif


### PR DESCRIPTION
This is helpful when using `ifup -v` to debug people's configs.