### PR TITLE
create/destroy phases for interfaces

### DIFF
--- a/doc/ifupdown-executor.scd
+++ b/doc/ifupdown-executor.scd
@@ -12,7 +12,7 @@ protocol documented in this man page.
 
 # PHASES
 
-Executors are run to react to seven different phases and are not
+Executors are run to react to nine different phases and are not
 required to take any specific action.  These phases are:
 
 *depend*
@@ -23,6 +23,10 @@ required to take any specific action.  These phases are:
 	into the dependency graph.  If an executor does not have
 	any dependencies, it may simply exit 0 without doing
 	anything.
+
+*create*
+	Called before *pre-up*, to explicitly allow for interface
+	creation if necessary.
 
 *pre-up*
 	Called before the interface is going to be brought up.
@@ -41,6 +45,10 @@ required to take any specific action.  These phases are:
 
 *post-down*
 	Called after the interface was successfully taken down.
+
+*destroy*
+	Called after *post-down* to allow for explicitly
+	destroying an interface if necessary.
 
 # ENVIRONMENT
 

--- a/libifupdown/lifecycle.c
+++ b/libifupdown/lifecycle.c
@@ -352,6 +352,9 @@ lif_lifecycle_run(const struct lif_execute_opts *opts, struct lif_interface *ifa
 		 * but, right now neither debian ifupdown or busybox ifupdown do any recovery,
 		 * so we wont right now.
 		 */
+		if (!lif_lifecycle_run_phase(opts, iface, "create", lifname, up))
+			return false;
+
 		if (!lif_lifecycle_run_phase(opts, iface, "pre-up", lifname, up))
 			return false;
 
@@ -374,6 +377,9 @@ lif_lifecycle_run(const struct lif_execute_opts *opts, struct lif_interface *ifa
 			return false;
 
 		if (!lif_lifecycle_run_phase(opts, iface, "post-down", lifname, up))
+			return false;
+
+		if (!lif_lifecycle_run_phase(opts, iface, "destroy", lifname, up))
 			return false;
 
 		/* when going up, dependents go down last. */


### PR DESCRIPTION
Executors still need to be adjusted to make use of these phases, but will run unmodified.

Closes #64.