### PR TITLE
dependency graph: reverse-dependency coloring

### DIFF
--- a/cmd/ifquery.c
+++ b/cmd/ifquery.c
@@ -290,6 +290,12 @@ ifquery_main(int argc, char *argv[])
 		return EXIT_FAILURE;
 	}
 
+	if (!lif_lifecycle_count_rdepends(&exec_opts, &collection))
+	{
+		fprintf(stderr, "%s: could not validate dependency tree\n", argv0);
+		return EXIT_FAILURE;
+	}
+
 	/* --list --state is not allowed */
 	if (listing && listing_stat)
 		generic_usage(self_applet, EXIT_FAILURE);

--- a/cmd/ifquery.c
+++ b/cmd/ifquery.c
@@ -67,9 +67,9 @@ print_interface_dot(struct lif_dict *collection, struct lif_interface *iface, st
 		return;
 
 	if (parent != NULL)
-		printf("\"%s\" -> ", parent->ifname);
+		printf("\"%s (%zu)\" -> ", parent->ifname, parent->rdepends_count);
 
-	printf("\"%s\"", iface->ifname);
+	printf("\"%s (%zu)\"", iface->ifname, iface->rdepends_count);
 
 	printf("\n");
 

--- a/cmd/ifquery.c
+++ b/cmd/ifquery.c
@@ -290,7 +290,7 @@ ifquery_main(int argc, char *argv[])
 		return EXIT_FAILURE;
 	}
 
-	if (!lif_lifecycle_count_rdepends(&exec_opts, &collection))
+	if (lif_lifecycle_count_rdepends(&exec_opts, &collection) == -1)
 	{
 		fprintf(stderr, "%s: could not validate dependency tree\n", argv0);
 		return EXIT_FAILURE;

--- a/cmd/ifupdown.c
+++ b/cmd/ifupdown.c
@@ -229,6 +229,12 @@ ifupdown_main(int argc, char *argv[])
 		return EXIT_FAILURE;
 	}
 
+	if (!lif_lifecycle_count_rdepends(&exec_opts, &collection))
+	{
+		fprintf(stderr, "%s: could not validate dependency tree\n", argv0);
+		return EXIT_FAILURE;
+	}
+
 	if (!lif_state_sync(&state, &collection))
 	{
 		fprintf(stderr, "%s: could not sync state\n", argv0);

--- a/cmd/ifupdown.c
+++ b/cmd/ifupdown.c
@@ -101,15 +101,17 @@ skip_interface(struct lif_interface *iface, const char *ifname)
 
 	if (up && iface->refcount > 0)
 	{
-		fprintf(stderr, "%s: skipping %s (already configured), use --force to force configuration\n",
-			argv0, ifname);
+		if (exec_opts.verbose)
+			fprintf(stderr, "%s: skipping auto interface %s (already configured), use --force to force configuration\n",
+				argv0, ifname);
 		return true;
 	}
 
 	if (!up && iface->refcount == 0)
 	{
-		fprintf(stderr, "%s: skipping %s (already deconfigured), use --force to force deconfiguration\n",
-			argv0, ifname);
+		if (exec_opts.verbose)
+			fprintf(stderr, "%s: skipping auto interface %s (already deconfigured), use --force to force deconfiguration\n",
+				argv0, ifname);
 		return true;
 	}
 

--- a/cmd/ifupdown.c
+++ b/cmd/ifupdown.c
@@ -229,7 +229,7 @@ ifupdown_main(int argc, char *argv[])
 		return EXIT_FAILURE;
 	}
 
-	if (!lif_lifecycle_count_rdepends(&exec_opts, &collection))
+	if (lif_lifecycle_count_rdepends(&exec_opts, &collection) == -1)
 	{
 		fprintf(stderr, "%s: could not validate dependency tree\n", argv0);
 		return EXIT_FAILURE;

--- a/libifupdown/interface.h
+++ b/libifupdown/interface.h
@@ -53,7 +53,8 @@ struct lif_interface {
 
 	struct lif_dict vars;
 
-	size_t refcount;	/* >= 0 if up, else 0 */
+	size_t refcount;	/* > 0 if up, else 0 */
+	size_t rdepends_count;	/* > 0 if any reverse dependency */
 };
 
 #define LIF_INTERFACE_COLLECTION_FOREACH(iter, collection) \

--- a/libifupdown/lifecycle.c
+++ b/libifupdown/lifecycle.c
@@ -419,7 +419,7 @@ count_interface_rdepends(const struct lif_execute_opts *opts, struct lif_dict *c
 	return true;
 }
 
-bool
+ssize_t
 lif_lifecycle_count_rdepends(const struct lif_execute_opts *opts, struct lif_dict *collection)
 {
 	struct lif_node *iter;
@@ -435,9 +435,21 @@ lif_lifecycle_count_rdepends(const struct lif_execute_opts *opts, struct lif_dic
 		if (!count_interface_rdepends(opts, collection, iface, iface->rdepends_count))
 		{
 			fprintf(stderr, "ifupdown: dependency graph is broken for interface %s\n", iface->ifname);
-			return false;
+			return -1;
 		}
 	}
 
-	return true;
+	/* figure out the max depth */
+	size_t maxdepth = 0;
+
+	LIF_DICT_FOREACH(iter, collection)
+	{
+		struct lif_dict_entry *entry = iter->data;
+		struct lif_interface *iface = entry->data;
+
+		if (iface->rdepends_count > maxdepth)
+			maxdepth = iface->rdepends_count;
+	}
+
+	return maxdepth;
 }

--- a/libifupdown/lifecycle.c
+++ b/libifupdown/lifecycle.c
@@ -339,9 +339,6 @@ lif_lifecycle_run(const struct lif_execute_opts *opts, struct lif_interface *ifa
 	if (lifname == NULL)
 		lifname = iface->ifname;
 
-	if (!lif_lifecycle_query_dependents(opts, iface, lifname))
-		return false;
-
 	if (up)
 	{
 		/* when going up, dependents go up first. */

--- a/libifupdown/lifecycle.h
+++ b/libifupdown/lifecycle.h
@@ -22,7 +22,7 @@
 extern bool lif_lifecycle_query_dependents(const struct lif_execute_opts *opts, struct lif_interface *iface, const char *lifname);
 extern bool lif_lifecycle_run_phase(const struct lif_execute_opts *opts, struct lif_interface *iface, const char *phase, const char *lifname, bool up);
 extern bool lif_lifecycle_run(const struct lif_execute_opts *opts, struct lif_interface *iface, struct lif_dict *collection, struct lif_dict *state, const char *lifname, bool up);
-extern bool lif_lifecycle_count_rdepends(const struct lif_execute_opts *opts, struct lif_dict *collection);
+extern ssize_t lif_lifecycle_count_rdepends(const struct lif_execute_opts *opts, struct lif_dict *collection);
 
 #endif
 

--- a/libifupdown/lifecycle.h
+++ b/libifupdown/lifecycle.h
@@ -22,6 +22,7 @@
 extern bool lif_lifecycle_query_dependents(const struct lif_execute_opts *opts, struct lif_interface *iface, const char *lifname);
 extern bool lif_lifecycle_run_phase(const struct lif_execute_opts *opts, struct lif_interface *iface, const char *phase, const char *lifname, bool up);
 extern bool lif_lifecycle_run(const struct lif_execute_opts *opts, struct lif_interface *iface, struct lif_dict *collection, struct lif_dict *state, const char *lifname, bool up);
+extern bool lif_lifecycle_count_rdepends(const struct lif_execute_opts *opts, struct lif_dict *collection);
 
 #endif
 

--- a/tests/fixtures/teardown-dep-ordering.ifstate
+++ b/tests/fixtures/teardown-dep-ordering.ifstate
@@ -1,0 +1,3 @@
+dummy=dummy 2
+bat=bat 2
+br=br 1

--- a/tests/fixtures/teardown-dep-ordering.interfaces
+++ b/tests/fixtures/teardown-dep-ordering.interfaces
@@ -1,0 +1,13 @@
+auto dummy
+iface dummy
+	link-type dummy
+
+auto bat
+iface bat
+	link-type dummy
+	requires dummy
+
+auto br
+iface br
+	link-type dummy
+	requires bat

--- a/tests/ifdown_test
+++ b/tests/ifdown_test
@@ -22,6 +22,7 @@ tests_init \
 	deferred_teardown_1 \
 	deferred_teardown_2 \
 	deferred_teardown_3 \
+	teardown_dep_ordering \
 	regress_opt_f
 
 noargs_body() {
@@ -170,6 +171,14 @@ deferred_teardown_3_body() {
 		-e match:"changing state of dependent interface eth0 \\(of tun3\\) to down" \
 		ifdown -n -S $FIXTURES/deferred-teardown-2.ifstate -E $EXECUTORS \
 			-i $FIXTURES/deferred-teardown-2.interfaces tun0 tun1 tun2 tun3
+}
+
+teardown_dep_ordering_body() {
+	atf_check -s exit:0 -o ignore \
+		-e match:"skipping auto interface bat" \
+		-e match:"skipping auto interface dummy" \
+		ifdown -n -i $FIXTURES/teardown-dep-ordering.interfaces \
+			-S $FIXTURES/teardown-dep-ordering.ifstate -E $EXECUTORS -a
 }
 
 regress_opt_f_body() {

--- a/tests/ifup_test
+++ b/tests/ifup_test
@@ -18,7 +18,8 @@ tests_init \
 	learned_dependency \
 	learned_dependency_2 \
 	learned_executor \
-	implicit_vlan
+	implicit_vlan \
+	teardown_dep_ordering
 
 noargs_body() {
 	atf_check -s exit:1 -e ignore ifup -S/dev/null
@@ -130,4 +131,11 @@ implicit_vlan_body() {
 		-e match:"attempting to run vlan executor" \
 		-e match:"attempting to run link executor" \
 		ifup -n -S/dev/null -E $EXECUTORS -i $FIXTURES/vlan.interfaces eth0.8
+}
+
+teardown_dep_ordering_body() {
+	atf_check -s exit:0 -o ignore \
+		-e match:"skipping auto interface bat" \
+		-e match:"skipping auto interface dummy" \
+		ifup -n -i $FIXTURES/teardown-dep-ordering.interfaces -E $EXECUTORS -a
 }


### PR DESCRIPTION
Color the dependency graph with reverse dependency information and use this to re-order the interface collection.

This reorders the auto interface list in such a way that the dependency solver's solution will be aligned regardless of order in the config file.

We add tests to verify that auto interfaces are appropriately skipped (due to being initialized earlier by the dependency solver).

Closes #71.