### PR TITLE
ethtool support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,8 @@ EXECUTOR_SCRIPTS_OPT ?= \
 	vrf \
 	tunnel \
 	gre \
-	wireguard
+	wireguard \
+	ethtool
 
 EXECUTOR_SCRIPTS ?= ${EXECUTOR_SCRIPTS_CORE} ${EXECUTOR_SCRIPTS_OPT}
 

--- a/executor-scripts/linux/ethtool
+++ b/executor-scripts/linux/ethtool
@@ -1,0 +1,2 @@
+#!/bin/sh
+set -e

--- a/executor-scripts/linux/ethtool
+++ b/executor-scripts/linux/ethtool
@@ -1,2 +1,13 @@
 #!/bin/sh
 set -e
+
+case "$PHASE" in
+pre-up)
+	settings=
+	[ -n "$IF_ETHTOOL_ETHERNET_PORT" ] && settings="port $IF_ETHTOOL_ETHERNET_PORT"
+	[ -n "$IF_ETHTOOL_MSGLVL" ] && settings="msglvl $IF_ETHTOOL_MSGLVL"
+	[ -z "$settings" ] || ethtool --change "$IFACE" $settings
+	;;
+up)
+	;;
+esac

--- a/executor-scripts/linux/ethtool
+++ b/executor-scripts/linux/ethtool
@@ -3,11 +3,34 @@ set -e
 
 case "$PHASE" in
 pre-up)
-	settings=
-	[ -n "$IF_ETHTOOL_ETHERNET_PORT" ] && settings="port $IF_ETHTOOL_ETHERNET_PORT"
-	[ -n "$IF_ETHTOOL_MSGLVL" ] && settings="msglvl $IF_ETHTOOL_MSGLVL"
-	[ -z "$settings" ] || ethtool --change "$IFACE" $settings
+	settings="\
+	${IF_ETHTOOL_ETHERNET_PORT:+ port $IF_ETHTOOL_ETHERNET_PORT}
+	${IF_ETHTOOL_MSGLVL:+ msglvl $IF_ETHTOOL_MSGLVL}
+	"
+	[ -z "$settings" ] || $MOCK ethtool --change "$IFACE" $settings
 	;;
 up)
+	# first do the link settings.
+	link_settings="\
+	${IF_ETHTOOL_LINK_SPEED:+ speed $IF_ETHTOOL_LINK_SPEED}
+	${IF_ETHTOOL_LINK_DUPLEX:+ duplex $IF_ETHTOOL_LINK_DUPLEX}
+	"
+
+	# ethernet-wol can have a second arg (key), split into $1 and $2
+	set -- $IF_ETHTOOL_ETHERNET_WOL
+	link_settings="$link_settings${1:+ wol $1}${2:+ sopass $2}"
+
+	# handle ethtool-ethernet-autoneg like Debian would
+	case "$IF_ETHTOOL_ETHERNET_AUTONEG" in
+	on|off)
+		link_settings="$link_settings autoneg $IF_ETHTOOL_ETHERNET_AUTONEG"
+		;;
+	*)
+		link_settings="$link_settings autoneg on advertise $IF_ETHTOOL_ETHERNET_AUTONEG"
+		;;
+	esac
+
+	[ -z "$link_settings" ] || $MOCK ethtool --change "$IFACE" $link_settings
+
 	;;
 esac

--- a/executor-scripts/linux/ethtool
+++ b/executor-scripts/linux/ethtool
@@ -46,7 +46,7 @@ up)
 
 	[ -z "$link_settings" ] || $MOCK ethtool --change "$IFACE" $link_settings
 
-	pause_settings=$(gather_params IF_ETHTOOL_ETHERNET_PAUSE)
+	pause_settings=$(gather_params IF_ETHTOOL_PAUSE)
 	[ -z "$pause_settings" ] || $MOCK ethtool --pause "$IFACE" $pause_settings
 
 	offload_settings=$(gather_params IF_ETHTOOL_OFFLOAD)

--- a/executor-scripts/linux/ethtool
+++ b/executor-scripts/linux/ethtool
@@ -53,5 +53,8 @@ up)
 
 	dma_settings=$(gather_params ETHTOOL_DMA_RING)
 	[ -z "$dma_settings" ] || $MOCK ethtool --set-ring "$IFACE" $dma_settings
+
+	coalesce_settings=$(gather_params ETHTOOL_COALESCE)
+	[ -z "$coalesce_settings" ] || $MOCK ethtool --coalesce "$IFACE" $coalesce_settings
 	;;
 esac

--- a/executor-scripts/linux/ethtool
+++ b/executor-scripts/linux/ethtool
@@ -12,7 +12,7 @@ gather_params() {
 		y/ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrstuvwxyz/
 		P
 		g
-	        s/.*\n//"
+	        s/.*\n//" | sed -E "s/_/-/g"
 }
 
 case "$PHASE" in

--- a/executor-scripts/linux/ethtool
+++ b/executor-scripts/linux/ethtool
@@ -3,7 +3,7 @@ set -e
 
 # gather params for a given prefix, based on executor-scripts/linux/tunnel.
 gather_params() {
-	set | sed -E "
+	env | sed -E "
 		s/^IF_${1}_([A-Z0-9_]+)=(.+)/\1\n\2/
 		ta
 		d

--- a/executor-scripts/linux/ethtool
+++ b/executor-scripts/linux/ethtool
@@ -50,5 +50,8 @@ up)
 
 	offload_settings=$(gather_params ETHTOOL_OFFLOAD)
 	[ -z "$offload_settings" ] || $MOCK ethtool --offload "$IFACE" $offload_settings
+
+	dma_settings=$(gather_params ETHTOOL_DMA_RING)
+	[ -z "$dma_settings" ] || $MOCK ethtool --set-ring "$IFACE" $dma_settings
 	;;
 esac

--- a/executor-scripts/linux/ethtool
+++ b/executor-scripts/linux/ethtool
@@ -25,10 +25,7 @@ pre-up)
 	;;
 up)
 	# first do the link settings.
-	link_settings="\
-	${IF_ETHTOOL_LINK_SPEED:+ speed $IF_ETHTOOL_LINK_SPEED}
-	${IF_ETHTOOL_LINK_DUPLEX:+ duplex $IF_ETHTOOL_LINK_DUPLEX}
-	"
+	link_settings="${IF_ETHTOOL_LINK_SPEED:+ speed $IF_ETHTOOL_LINK_SPEED}${IF_ETHTOOL_LINK_DUPLEX:+ duplex $IF_ETHTOOL_LINK_DUPLEX}"
 
 	# ethernet-wol can have a second arg (key), split into $1 and $2
 	set -- $IF_ETHTOOL_ETHERNET_WOL
@@ -36,6 +33,8 @@ up)
 
 	# handle ethtool-ethernet-autoneg like Debian would
 	case "$IF_ETHTOOL_ETHERNET_AUTONEG" in
+	'')
+		;;
 	on|off)
 		link_settings="$link_settings autoneg $IF_ETHTOOL_ETHERNET_AUTONEG"
 		;;
@@ -46,10 +45,10 @@ up)
 
 	[ -z "$link_settings" ] || $MOCK ethtool --change "$IFACE" $link_settings
 
-	pause_settings=$(gather_params IF_ETHTOOL_PAUSE)
+	pause_settings=$(gather_params ETHTOOL_PAUSE)
 	[ -z "$pause_settings" ] || $MOCK ethtool --pause "$IFACE" $pause_settings
 
-	offload_settings=$(gather_params IF_ETHTOOL_OFFLOAD)
+	offload_settings=$(gather_params ETHTOOL_OFFLOAD)
 	[ -z "$offload_settings" ] || $MOCK ethtool --offload "$IFACE" $offload_settings
 	;;
 esac

--- a/executor-scripts/linux/ethtool
+++ b/executor-scripts/linux/ethtool
@@ -1,6 +1,20 @@
 #!/bin/sh
 set -e
 
+# gather params for a given prefix, based on executor-scripts/linux/tunnel.
+gather_params() {
+	set | sed -E "
+		s/^IF_${1}_([A-Z0-9_]+)=(.+)/\1\n\2/
+		ta
+		d
+		:a
+		h
+		y/ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrstuvwxyz/
+		P
+		g
+	        s/.*\n//"
+}
+
 case "$PHASE" in
 pre-up)
 	settings="\
@@ -32,5 +46,10 @@ up)
 
 	[ -z "$link_settings" ] || $MOCK ethtool --change "$IFACE" $link_settings
 
+	pause_settings=$(gather_params IF_ETHTOOL_ETHERNET_PAUSE)
+	[ -z "$pause_settings" ] || $MOCK ethtool --pause "$IFACE" $pause_settings
+
+	offload_settings=$(gather_params IF_ETHTOOL_OFFLOAD)
+	[ -z "$offload_settings" ] || $MOCK ethtool --offload "$IFACE" $offload_settings
 	;;
 esac

--- a/libifupdown/interface-file.c
+++ b/libifupdown/interface-file.c
@@ -37,6 +37,10 @@ static const struct remap_token tokens[] = {
 	{"ethernet-wol", "ethtool-ethernet-wol"},	/* Debian ethtool integration */
 	{"gro-offload", "ethtool-offload-gro"},		/* ifupdown2 */
 	{"gso-offload", "ethtool-offload-gso"},		/* ifupdown2 */
+	{"hardware-dma-ring-rx", "ethtool-dma-ring-rx"},		/* Debian ethtool integration */
+	{"hardware-dma-ring-rx-jumbo", "ethtool-dma-ring-rx-jumbo"},	/* Debian ethtool integration */
+	{"hardware-dma-ring-rx-mini", "ethtool-dma-ring-rx-mini"},	/* Debian ethtool integration */
+	{"hardware-dma-ring-tx", "ethtool-dma-ring-tx"},		/* Debian ethtool integration */
 	{"link-autoneg", "ethtool-ethernet-autoneg"},	/* ifupdown2 */
 	{"link-duplex", "ethtool-link-duplex"},		/* Debian ethtool integration */
 	{"link-fec", "ethtool-link-fec"},		/* ifupdown2 */

--- a/libifupdown/interface-file.c
+++ b/libifupdown/interface-file.c
@@ -41,6 +41,28 @@ static const struct remap_token tokens[] = {
 	{"hardware-dma-ring-rx-jumbo", "ethtool-dma-ring-rx-jumbo"},	/* Debian ethtool integration */
 	{"hardware-dma-ring-rx-mini", "ethtool-dma-ring-rx-mini"},	/* Debian ethtool integration */
 	{"hardware-dma-ring-tx", "ethtool-dma-ring-tx"},		/* Debian ethtool integration */
+	{"hardware-irq-coalesce-adaptive-rx", "ethtool-coalesce-adaptive-rx"},			/* Debian ethtool integration */
+	{"hardware-irq-coalesce-adaptive-tx", "ethtool-coalesce-adaptive-tx"},			/* Debian ethtool integration */
+	{"hardware-irq-coalesce-pkt-rate-high", "ethtool-coalesce-pkt-rate-high"},		/* Debian ethtool integration */
+	{"hardware-irq-coalesce-pkt-rate-low", "ethtool-coalesce-pkt-rate-low"},		/* Debian ethtool integration */
+	{"hardware-irq-coalesce-rx-frames", "ethtool-coalesce-rx-frames"},			/* Debian ethtool integration */
+	{"hardware-irq-coalesce-rx-frames-high", "ethtool-coalesce-rx-frames-high"},		/* Debian ethtool integration */
+	{"hardware-irq-coalesce-rx-frames-irq", "ethtool-coalesce-rx-frames-irq"},		/* Debian ethtool integration */
+	{"hardware-irq-coalesce-rx-frames-low", "ethtool-coalesce-rx-frames-low"},		/* Debian ethtool integration */
+	{"hardware-irq-coalesce-rx-usecs", "ethtool-coalesce-rx-usecs"},			/* Debian ethtool integration */
+	{"hardware-irq-coalesce-rx-usecs-high", "ethtool-coalesce-rx-usecs-high"},		/* Debian ethtool integration */
+	{"hardware-irq-coalesce-rx-usecs-irq", "ethtool-coalesce-rx-usecs-irq"},		/* Debian ethtool integration */
+	{"hardware-irq-coalesce-rx-usecs-low", "ethtool-coalesce-rx-usecs-low"},		/* Debian ethtool integration */
+	{"hardware-irq-coalesce-sample-interval", "ethtool-coalesce-sample-interval"},		/* Debian ethtool integration */
+	{"hardware-irq-coalesce-stats-block-usecs", "ethtool-coalesce-stats-block-usecs"},	/* Debian ethtool integration */
+	{"hardware-irq-coalesce-tx-frames", "ethtool-coalesce-tx-frames"},			/* Debian ethtool integration */
+	{"hardware-irq-coalesce-tx-frames-high", "ethtool-coalesce-tx-frames-high"},		/* Debian ethtool integration */
+	{"hardware-irq-coalesce-tx-frames-irq", "ethtool-coalesce-tx-frames-irq"},		/* Debian ethtool integration */
+	{"hardware-irq-coalesce-tx-frames-low", "ethtool-coalesce-tx-frames-low"},		/* Debian ethtool integration */
+	{"hardware-irq-coalesce-tx-usecs", "ethtool-coalesce-tx-usecs"},			/* Debian ethtool integration */
+	{"hardware-irq-coalesce-tx-usecs-high", "ethtool-coalesce-tx-usecs-high"},		/* Debian ethtool integration */
+	{"hardware-irq-coalesce-tx-usecs-irq", "ethtool-coalesce-tx-usecs-irq"},		/* Debian ethtool integration */
+	{"hardware-irq-coalesce-tx-usecs-low", "ethtool-coalesce-tx-usecs-low"},		/* Debian ethtool integration */
 	{"link-autoneg", "ethtool-ethernet-autoneg"},	/* ifupdown2 */
 	{"link-duplex", "ethtool-link-duplex"},		/* Debian ethtool integration */
 	{"link-fec", "ethtool-link-fec"},		/* ifupdown2 */

--- a/libifupdown/interface-file.c
+++ b/libifupdown/interface-file.c
@@ -37,6 +37,7 @@ static const struct remap_token tokens[] = {
 	{"ethernet-wol", "ethtool-ethernet-wol"},	/* Debian ethtool integration */
 	{"gro-offload", "ethtool-offload-gro"},		/* ifupdown2 */
 	{"gso-offload", "ethtool-offload-gso"},		/* ifupdown2 */
+	{"link-autoneg", "ethtool-ethernet-autoneg"},	/* ifupdown2 */
 	{"link-duplex", "ethtool-link-duplex"},		/* Debian ethtool integration */
 	{"link-fec", "ethtool-link-fec"},		/* ifupdown2 */
 	{"link-speed", "ethtool-link-speed"},		/* Debian ethtool integration */

--- a/libifupdown/interface-file.c
+++ b/libifupdown/interface-file.c
@@ -27,13 +27,38 @@ struct remap_token {
 
 /* this list must be in alphabetical order for bsearch */
 static const struct remap_token tokens[] = {
+	{"driver-message-level", "ethtool-msglvl"},	/* Debian ethtool integration */
 	{"endpoint", "tunnel-remote"},			/* legacy ifupdown */
+	{"ethernet-autoneg", "ethtool-ethernet-autoneg"},	/* Debian ethtool integration */
+	{"ethernet-pause-autoneg", "ethtool-pause-autoneg"},	/* Debian ethtool integration */
+	{"ethernet-pause-rx", "ethtool-pause-rx"},	/* Debian ethtool integration */
+	{"ethernet-pause-tx", "ethtool-pause-tx"},	/* Debian ethtool integration */
+	{"ethernet-port", "ethtool-ethernet-port"},	/* Debian ethtool integration */
+	{"ethernet-wol", "ethtool-ethernet-wol"},	/* Debian ethtool integration */
+	{"gro-offload", "ethtool-offload-gro"},		/* ifupdown2 */
+	{"gso-offload", "ethtool-offload-gso"},		/* ifupdown2 */
+	{"link-duplex", "ethtool-link-duplex"},		/* Debian ethtool integration */
+	{"link-fec", "ethtool-link-fec"},		/* ifupdown2 */
+	{"link-speed", "ethtool-link-speed"},		/* Debian ethtool integration */
 	{"local", "tunnel-local"},			/* legacy ifupdown */
+	{"lro-offload", "ethtool-offload-lro"},		/* ifupdown2 */
 	{"mode", "tunnel-mode"},			/* legacy ifupdown */
+	{"offload-gro", "ethtool-offload-gro"},		/* Debian ethtool integration */
+	{"offload-gso", "ethtool-offload-gso"},		/* Debian ethtool integration */
+	{"offload-lro", "ethtool-offload-lro"},		/* Debian ethtool integration */
+	{"offload-rx", "ethtool-offload-rx"},		/* Debian ethtool integration */
+	{"offload-sg", "ethtool-offload-sg"},		/* Debian ethtool integration */
+	{"offload-tso", "ethtool-offload-tso"},		/* Debian ethtool integration */
+	{"offload-tx", "ethtool-offload-tx"},		/* Debian ethtool integration */
+	{"offload-ufo", "ethtool-offload-ufo"},		/* Debian ethtool integration */
 	{"provider", "ppp-provider"},			/* legacy ifupdown, ifupdown2 */
+	{"rx-offload", "ethtool-offload-rx"},		/* ifupdown2 */
+	{"tso-offload", "ethtool-offload-tso"},		/* ifupdown2 */
 	{"ttl", "tunnel-ttl"},				/* legacy ifupdown */
 	{"tunnel-endpoint", "tunnel-remote"},		/* ifupdown2 */
 	{"tunnel-physdev", "tunnel-dev"},		/* ifupdown2 */
+	{"tx-offload", "ethtool-offload-tx"},		/* ifupdown2 */
+	{"ufo-offload", "ethtool-offload-ufo"},		/* ifupdown2 */
 	{"vrf", "vrf-member"},				/* ifupdown2 */
 };
 

--- a/tests/linux/Kyuafile
+++ b/tests/linux/Kyuafile
@@ -11,3 +11,4 @@ atf_test_program{name='ppp_test'}
 atf_test_program{name='tunnel_test'}
 atf_test_program{name='gre_test'}
 atf_test_program{name='wireguard_test'}
+atf_test_program{name='ethtool_test'}

--- a/tests/linux/ethtool_test
+++ b/tests/linux/ethtool_test
@@ -26,7 +26,29 @@ tests_init \
 	up_dma_ring_rx \
 	up_dma_ring_rx_jumbo \
 	up_dma_ring_rx_mini \
-	up_dma_ring_tx
+	up_dma_ring_tx \
+	up_coalesce_adaptive_rx \
+	up_coalesce_adaptive_tx \
+	up_coalesce_pkt_rate_low \
+	up_coalesce_pkt_rate_high \
+	up_coalesce_sample_interval \
+	up_coalesce_stats_block_usecs \
+	up_coalesce_rx_frames \
+	up_coalesce_rx_frames_low \
+	up_coalesce_rx_frames_irq \
+	up_coalesce_rx_frames_high \
+	up_coalesce_rx_usecs \
+	up_coalesce_rx_usecs_low \
+	up_coalesce_rx_usecs_irq \
+	up_coalesce_rx_usecs_high \
+	up_coalesce_tx_frames \
+	up_coalesce_tx_frames_low \
+	up_coalesce_tx_frames_irq \
+	up_coalesce_tx_frames_high \
+	up_coalesce_tx_usecs \
+	up_coalesce_tx_usecs_low \
+	up_coalesce_tx_usecs_irq \
+	up_coalesce_tx_usecs_high
 
 pre_up_msglvl_body() {
 	export IFACE="eth0" PHASE="pre-up" IF_ETHTOOL_MSGLVL="debug on" MOCK="echo"
@@ -281,5 +303,181 @@ up_dma_ring_tx_body() {
 	atf_check -s exit:0 \
 		-o match:'ethtool --set-ring eth0' \
 		-o match:"tx '1024'" \
+		${EXECUTOR}
+}
+
+up_coalesce_adaptive_rx_body() {
+	export IFACE="eth0" PHASE="up" IF_ETHTOOL_COALESCE_ADAPTIVE_RX="on" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --coalesce eth0' \
+		-o match:"adaptive-rx 'on'" \
+		${EXECUTOR}
+}
+
+up_coalesce_adaptive_tx_body() {
+	export IFACE="eth0" PHASE="up" IF_ETHTOOL_COALESCE_ADAPTIVE_TX="on" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --coalesce eth0' \
+		-o match:"adaptive-tx 'on'" \
+		${EXECUTOR}
+}
+
+up_coalesce_pkt_rate_low_body() {
+	export IFACE="eth0" PHASE="up" IF_ETHTOOL_COALESCE_PKT_RATE_LOW="1024" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --coalesce eth0' \
+		-o match:"pkt-rate-low '1024'" \
+		${EXECUTOR}
+}
+
+up_coalesce_pkt_rate_high_body() {
+	export IFACE="eth0" PHASE="up" IF_ETHTOOL_COALESCE_PKT_RATE_HIGH="1024" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --coalesce eth0' \
+		-o match:"pkt-rate-high '1024'" \
+		${EXECUTOR}
+}
+
+up_coalesce_sample_interval_body() {
+	export IFACE="eth0" PHASE="up" IF_ETHTOOL_COALESCE_SAMPLE_INTERVAL="1024" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --coalesce eth0' \
+		-o match:"sample-interval '1024'" \
+		${EXECUTOR}
+}
+
+up_coalesce_stats_block_usecs_body() {
+	export IFACE="eth0" PHASE="up" IF_ETHTOOL_COALESCE_STATS_BLOCK_USECS="1024" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --coalesce eth0' \
+		-o match:"stats-block-usecs '1024'" \
+		${EXECUTOR}
+}
+
+up_coalesce_rx_frames_body() {
+	export IFACE="eth0" PHASE="up" IF_ETHTOOL_COALESCE_RX_FRAMES="1024" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --coalesce eth0' \
+		-o match:"rx-frames '1024'" \
+		${EXECUTOR}
+}
+
+up_coalesce_rx_frames_low_body() {
+	export IFACE="eth0" PHASE="up" IF_ETHTOOL_COALESCE_RX_FRAMES_LOW="1024" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --coalesce eth0' \
+		-o match:"rx-frames-low '1024'" \
+		${EXECUTOR}
+}
+
+up_coalesce_rx_frames_irq_body() {
+	export IFACE="eth0" PHASE="up" IF_ETHTOOL_COALESCE_RX_FRAMES_IRQ="1024" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --coalesce eth0' \
+		-o match:"rx-frames-irq '1024'" \
+		${EXECUTOR}
+}
+
+up_coalesce_rx_frames_high_body() {
+	export IFACE="eth0" PHASE="up" IF_ETHTOOL_COALESCE_RX_FRAMES_HIGH="1024" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --coalesce eth0' \
+		-o match:"rx-frames-high '1024'" \
+		${EXECUTOR}
+}
+
+up_coalesce_rx_usecs_body() {
+	export IFACE="eth0" PHASE="up" IF_ETHTOOL_COALESCE_RX_USECS="1024" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --coalesce eth0' \
+		-o match:"rx-usecs '1024'" \
+		${EXECUTOR}
+}
+
+up_coalesce_rx_usecs_low_body() {
+	export IFACE="eth0" PHASE="up" IF_ETHTOOL_COALESCE_RX_USECS_LOW="1024" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --coalesce eth0' \
+		-o match:"rx-usecs-low '1024'" \
+		${EXECUTOR}
+}
+
+up_coalesce_rx_usecs_irq_body() {
+	export IFACE="eth0" PHASE="up" IF_ETHTOOL_COALESCE_RX_USECS_IRQ="1024" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --coalesce eth0' \
+		-o match:"rx-usecs-irq '1024'" \
+		${EXECUTOR}
+}
+
+up_coalesce_rx_usecs_high_body() {
+	export IFACE="eth0" PHASE="up" IF_ETHTOOL_COALESCE_RX_USECS_HIGH="1024" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --coalesce eth0' \
+		-o match:"rx-usecs-high '1024'" \
+		${EXECUTOR}
+}
+
+up_coalesce_tx_frames_body() {
+	export IFACE="eth0" PHASE="up" IF_ETHTOOL_COALESCE_TX_FRAMES="1024" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --coalesce eth0' \
+		-o match:"tx-frames '1024'" \
+		${EXECUTOR}
+}
+
+up_coalesce_tx_frames_low_body() {
+	export IFACE="eth0" PHASE="up" IF_ETHTOOL_COALESCE_TX_FRAMES_LOW="1024" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --coalesce eth0' \
+		-o match:"tx-frames-low '1024'" \
+		${EXECUTOR}
+}
+
+up_coalesce_tx_frames_irq_body() {
+	export IFACE="eth0" PHASE="up" IF_ETHTOOL_COALESCE_TX_FRAMES_IRQ="1024" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --coalesce eth0' \
+		-o match:"tx-frames-irq '1024'" \
+		${EXECUTOR}
+}
+
+up_coalesce_tx_frames_high_body() {
+	export IFACE="eth0" PHASE="up" IF_ETHTOOL_COALESCE_TX_FRAMES_HIGH="1024" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --coalesce eth0' \
+		-o match:"tx-frames-high '1024'" \
+		${EXECUTOR}
+}
+
+up_coalesce_tx_usecs_body() {
+	export IFACE="eth0" PHASE="up" IF_ETHTOOL_COALESCE_TX_USECS="1024" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --coalesce eth0' \
+		-o match:"tx-usecs '1024'" \
+		${EXECUTOR}
+}
+
+up_coalesce_tx_usecs_low_body() {
+	export IFACE="eth0" PHASE="up" IF_ETHTOOL_COALESCE_TX_USECS_LOW="1024" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --coalesce eth0' \
+		-o match:"tx-usecs-low '1024'" \
+		${EXECUTOR}
+}
+
+up_coalesce_tx_usecs_irq_body() {
+	export IFACE="eth0" PHASE="up" IF_ETHTOOL_COALESCE_TX_USECS_IRQ="1024" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --coalesce eth0' \
+		-o match:"tx-usecs-irq '1024'" \
+		${EXECUTOR}
+}
+
+up_coalesce_tx_usecs_high_body() {
+	export IFACE="eth0" PHASE="up" IF_ETHTOOL_COALESCE_TX_USECS_HIGH="1024" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --coalesce eth0' \
+		-o match:"tx-usecs-high '1024'" \
 		${EXECUTOR}
 }

--- a/tests/linux/ethtool_test
+++ b/tests/linux/ethtool_test
@@ -22,7 +22,11 @@ tests_init \
 	up_offload_sg \
 	up_offload_tso \
 	up_offload_tx \
-	up_offload_ufo
+	up_offload_ufo \
+	up_dma_ring_rx \
+	up_dma_ring_rx_jumbo \
+	up_dma_ring_rx_mini \
+	up_dma_ring_tx
 
 pre_up_msglvl_body() {
 	export IFACE="eth0" PHASE="pre-up" IF_ETHTOOL_MSGLVL="debug on" MOCK="echo"
@@ -245,5 +249,37 @@ up_offload_ufo_body() {
 	atf_check -s exit:0 \
 		-o match:'ethtool --offload eth0' \
 		-o match:"ufo 'off'" \
+		${EXECUTOR}
+}
+
+up_dma_ring_rx_body() {
+	export IFACE="eth0" PHASE="up" IF_ETHTOOL_DMA_RING_RX="1024" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --set-ring eth0' \
+		-o match:"rx '1024'" \
+		${EXECUTOR}
+}
+
+up_dma_ring_rx_jumbo_body() {
+	export IFACE="eth0" PHASE="up" IF_ETHTOOL_DMA_RING_RX_JUMBO="1024" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --set-ring eth0' \
+		-o match:"rx-jumbo '1024'" \
+		${EXECUTOR}
+}
+
+up_dma_ring_rx_mini_body() {
+	export IFACE="eth0" PHASE="up" IF_ETHTOOL_DMA_RING_RX_MINI="1024" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --set-ring eth0' \
+		-o match:"rx-mini '1024'" \
+		${EXECUTOR}
+}
+
+up_dma_ring_tx_body() {
+	export IFACE="eth0" PHASE="up" IF_ETHTOOL_DMA_RING_TX="1024" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --set-ring eth0' \
+		-o match:"tx '1024'" \
 		${EXECUTOR}
 }

--- a/tests/linux/ethtool_test
+++ b/tests/linux/ethtool_test
@@ -1,0 +1,84 @@
+#!/usr/bin/env atf-sh
+
+. $(atf_get_srcdir)/../test_env.sh
+EXECUTOR="$(atf_get_srcdir)/../../executor-scripts/linux/ethtool"
+
+tests_init \
+	pre_up_msglvl \
+	pre_up_ethernet_port \
+	up_speed \
+	up_duplex \
+	up_wol \
+	up_wol_sopass \
+	up_autoneg_simple \
+	up_autoneg_mask
+
+pre_up_msglvl_body() {
+	export IFACE="eth0" PHASE="pre-up" IF_ETHTOOL_MSGLVL="debug on" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --change eth0' \
+		-o match:'msglvl debug on' \
+		${EXECUTOR}
+}
+
+pre_up_ethernet_port_body() {
+	export IFACE="eth0" PHASE="pre-up" IF_ETHTOOL_ETHERNET_PORT="4" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --change eth0' \
+		-o match:'port 4' \
+		${EXECUTOR}
+}
+
+up_speed_body() {
+	export IFACE="eth0" PHASE="up" IF_ETHTOOL_LINK_SPEED="1000" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --change eth0' \
+		-o match:'speed 1000' \
+		${EXECUTOR}
+}
+
+up_duplex_body() {
+	export IFACE="eth0" PHASE="up" IF_ETHTOOL_LINK_DUPLEX="full" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --change eth0' \
+		-o match:'duplex full' \
+		${EXECUTOR}
+}
+
+up_wol_body() {
+	export IFACE="eth0" PHASE="up" IF_ETHTOOL_ETHERNET_WOL="g" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --change eth0' \
+		-o match:'wol g' \
+		${EXECUTOR}
+}
+
+up_wol_sopass_body() {
+	export IFACE="eth0" PHASE="up" IF_ETHTOOL_ETHERNET_WOL="s abc123" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --change eth0' \
+		-o match:'wol s sopass abc123' \
+		${EXECUTOR}
+}
+
+up_autoneg_simple_body() {
+	export IFACE="eth0" PHASE="up" IF_ETHTOOL_ETHERNET_AUTONEG="on" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --change eth0' \
+		-o match:'autoneg on' \
+		${EXECUTOR}
+
+	export IFACE="eth0" PHASE="up" IF_ETHTOOL_ETHERNET_AUTONEG="off" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --change eth0' \
+		-o match:'autoneg off' \
+		${EXECUTOR}
+}
+
+up_autoneg_mask_body() {
+	export IFACE="eth0" PHASE="up" IF_ETHTOOL_ETHERNET_AUTONEG="1000/full" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --change eth0' \
+		-o match:'autoneg on advertise 1000/full' \
+		${EXECUTOR}
+}

--- a/tests/linux/ethtool_test
+++ b/tests/linux/ethtool_test
@@ -124,13 +124,13 @@ up_pause_autoneg_body() {
 	export IFACE="eth0" PHASE="up" IF_ETHTOOL_PAUSE_AUTONEG="on" MOCK="echo"
 	atf_check -s exit:0 \
 		-o match:'ethtool --pause eth0' \
-		-o match:"autoneg 'on'" \
+		-o match:"autoneg on" \
 		${EXECUTOR}
 
 	export IFACE="eth0" PHASE="up" IF_ETHTOOL_PAUSE_AUTONEG="off" MOCK="echo"
 	atf_check -s exit:0 \
 		-o match:'ethtool --pause eth0' \
-		-o match:"autoneg 'off'" \
+		-o match:"autoneg off" \
 		${EXECUTOR}
 }
 
@@ -138,13 +138,13 @@ up_pause_tx_body() {
 	export IFACE="eth0" PHASE="up" IF_ETHTOOL_PAUSE_TX="on" MOCK="echo"
 	atf_check -s exit:0 \
 		-o match:'ethtool --pause eth0' \
-		-o match:"tx 'on'" \
+		-o match:"tx on" \
 		${EXECUTOR}
 
 	export IFACE="eth0" PHASE="up" IF_ETHTOOL_PAUSE_TX="off" MOCK="echo"
 	atf_check -s exit:0 \
 		-o match:'ethtool --pause eth0' \
-		-o match:"tx 'off'" \
+		-o match:"tx off" \
 		${EXECUTOR}
 }
 
@@ -152,13 +152,13 @@ up_pause_rx_body() {
 	export IFACE="eth0" PHASE="up" IF_ETHTOOL_PAUSE_RX="on" MOCK="echo"
 	atf_check -s exit:0 \
 		-o match:'ethtool --pause eth0' \
-		-o match:"rx 'on'" \
+		-o match:"rx on" \
 		${EXECUTOR}
 
 	export IFACE="eth0" PHASE="up" IF_ETHTOOL_PAUSE_RX="off" MOCK="echo"
 	atf_check -s exit:0 \
 		-o match:'ethtool --pause eth0' \
-		-o match:"rx 'off'" \
+		-o match:"rx off" \
 		${EXECUTOR}
 }
 
@@ -166,13 +166,13 @@ up_offload_gro_body() {
 	export IFACE="eth0" PHASE="up" IF_ETHTOOL_OFFLOAD_GRO="on" MOCK="echo"
 	atf_check -s exit:0 \
 		-o match:'ethtool --offload eth0' \
-		-o match:"gro 'on'" \
+		-o match:"gro on" \
 		${EXECUTOR}
 
 	export IFACE="eth0" PHASE="up" IF_ETHTOOL_OFFLOAD_GRO="off" MOCK="echo"
 	atf_check -s exit:0 \
 		-o match:'ethtool --offload eth0' \
-		-o match:"gro 'off'" \
+		-o match:"gro off" \
 		${EXECUTOR}
 }
 
@@ -180,13 +180,13 @@ up_offload_gso_body() {
 	export IFACE="eth0" PHASE="up" IF_ETHTOOL_OFFLOAD_GSO="on" MOCK="echo"
 	atf_check -s exit:0 \
 		-o match:'ethtool --offload eth0' \
-		-o match:"gso 'on'" \
+		-o match:"gso on" \
 		${EXECUTOR}
 
 	export IFACE="eth0" PHASE="up" IF_ETHTOOL_OFFLOAD_GSO="off" MOCK="echo"
 	atf_check -s exit:0 \
 		-o match:'ethtool --offload eth0' \
-		-o match:"gso 'off'" \
+		-o match:"gso off" \
 		${EXECUTOR}
 }
 
@@ -194,13 +194,13 @@ up_offload_lro_body() {
 	export IFACE="eth0" PHASE="up" IF_ETHTOOL_OFFLOAD_LRO="on" MOCK="echo"
 	atf_check -s exit:0 \
 		-o match:'ethtool --offload eth0' \
-		-o match:"lro 'on'" \
+		-o match:"lro on" \
 		${EXECUTOR}
 
 	export IFACE="eth0" PHASE="up" IF_ETHTOOL_OFFLOAD_LRO="off" MOCK="echo"
 	atf_check -s exit:0 \
 		-o match:'ethtool --offload eth0' \
-		-o match:"lro 'off'" \
+		-o match:"lro off" \
 		${EXECUTOR}
 }
 
@@ -208,13 +208,13 @@ up_offload_rx_body() {
 	export IFACE="eth0" PHASE="up" IF_ETHTOOL_OFFLOAD_RX="on" MOCK="echo"
 	atf_check -s exit:0 \
 		-o match:'ethtool --offload eth0' \
-		-o match:"rx 'on'" \
+		-o match:"rx on" \
 		${EXECUTOR}
 
 	export IFACE="eth0" PHASE="up" IF_ETHTOOL_OFFLOAD_RX="off" MOCK="echo"
 	atf_check -s exit:0 \
 		-o match:'ethtool --offload eth0' \
-		-o match:"rx 'off'" \
+		-o match:"rx off" \
 		${EXECUTOR}
 }
 
@@ -222,13 +222,13 @@ up_offload_sg_body() {
 	export IFACE="eth0" PHASE="up" IF_ETHTOOL_OFFLOAD_SG="on" MOCK="echo"
 	atf_check -s exit:0 \
 		-o match:'ethtool --offload eth0' \
-		-o match:"sg 'on'" \
+		-o match:"sg on" \
 		${EXECUTOR}
 
 	export IFACE="eth0" PHASE="up" IF_ETHTOOL_OFFLOAD_SG="off" MOCK="echo"
 	atf_check -s exit:0 \
 		-o match:'ethtool --offload eth0' \
-		-o match:"sg 'off'" \
+		-o match:"sg off" \
 		${EXECUTOR}
 }
 
@@ -236,13 +236,13 @@ up_offload_tso_body() {
 	export IFACE="eth0" PHASE="up" IF_ETHTOOL_OFFLOAD_TSO="on" MOCK="echo"
 	atf_check -s exit:0 \
 		-o match:'ethtool --offload eth0' \
-		-o match:"tso 'on'" \
+		-o match:"tso on" \
 		${EXECUTOR}
 
 	export IFACE="eth0" PHASE="up" IF_ETHTOOL_OFFLOAD_TSO="off" MOCK="echo"
 	atf_check -s exit:0 \
 		-o match:'ethtool --offload eth0' \
-		-o match:"tso 'off'" \
+		-o match:"tso off" \
 		${EXECUTOR}
 }
 
@@ -250,13 +250,13 @@ up_offload_tx_body() {
 	export IFACE="eth0" PHASE="up" IF_ETHTOOL_OFFLOAD_TX="on" MOCK="echo"
 	atf_check -s exit:0 \
 		-o match:'ethtool --offload eth0' \
-		-o match:"tx 'on'" \
+		-o match:"tx on" \
 		${EXECUTOR}
 
 	export IFACE="eth0" PHASE="up" IF_ETHTOOL_OFFLOAD_TX="off" MOCK="echo"
 	atf_check -s exit:0 \
 		-o match:'ethtool --offload eth0' \
-		-o match:"tx 'off'" \
+		-o match:"tx off" \
 		${EXECUTOR}
 }
 
@@ -264,13 +264,13 @@ up_offload_ufo_body() {
 	export IFACE="eth0" PHASE="up" IF_ETHTOOL_OFFLOAD_UFO="on" MOCK="echo"
 	atf_check -s exit:0 \
 		-o match:'ethtool --offload eth0' \
-		-o match:"ufo 'on'" \
+		-o match:"ufo on" \
 		${EXECUTOR}
 
 	export IFACE="eth0" PHASE="up" IF_ETHTOOL_OFFLOAD_UFO="off" MOCK="echo"
 	atf_check -s exit:0 \
 		-o match:'ethtool --offload eth0' \
-		-o match:"ufo 'off'" \
+		-o match:"ufo off" \
 		${EXECUTOR}
 }
 
@@ -278,7 +278,7 @@ up_dma_ring_rx_body() {
 	export IFACE="eth0" PHASE="up" IF_ETHTOOL_DMA_RING_RX="1024" MOCK="echo"
 	atf_check -s exit:0 \
 		-o match:'ethtool --set-ring eth0' \
-		-o match:"rx '1024'" \
+		-o match:"rx 1024" \
 		${EXECUTOR}
 }
 
@@ -286,7 +286,7 @@ up_dma_ring_rx_jumbo_body() {
 	export IFACE="eth0" PHASE="up" IF_ETHTOOL_DMA_RING_RX_JUMBO="1024" MOCK="echo"
 	atf_check -s exit:0 \
 		-o match:'ethtool --set-ring eth0' \
-		-o match:"rx-jumbo '1024'" \
+		-o match:"rx-jumbo 1024" \
 		${EXECUTOR}
 }
 
@@ -294,7 +294,7 @@ up_dma_ring_rx_mini_body() {
 	export IFACE="eth0" PHASE="up" IF_ETHTOOL_DMA_RING_RX_MINI="1024" MOCK="echo"
 	atf_check -s exit:0 \
 		-o match:'ethtool --set-ring eth0' \
-		-o match:"rx-mini '1024'" \
+		-o match:"rx-mini 1024" \
 		${EXECUTOR}
 }
 
@@ -302,7 +302,7 @@ up_dma_ring_tx_body() {
 	export IFACE="eth0" PHASE="up" IF_ETHTOOL_DMA_RING_TX="1024" MOCK="echo"
 	atf_check -s exit:0 \
 		-o match:'ethtool --set-ring eth0' \
-		-o match:"tx '1024'" \
+		-o match:"tx 1024" \
 		${EXECUTOR}
 }
 
@@ -310,7 +310,7 @@ up_coalesce_adaptive_rx_body() {
 	export IFACE="eth0" PHASE="up" IF_ETHTOOL_COALESCE_ADAPTIVE_RX="on" MOCK="echo"
 	atf_check -s exit:0 \
 		-o match:'ethtool --coalesce eth0' \
-		-o match:"adaptive-rx 'on'" \
+		-o match:"adaptive-rx on" \
 		${EXECUTOR}
 }
 
@@ -318,7 +318,7 @@ up_coalesce_adaptive_tx_body() {
 	export IFACE="eth0" PHASE="up" IF_ETHTOOL_COALESCE_ADAPTIVE_TX="on" MOCK="echo"
 	atf_check -s exit:0 \
 		-o match:'ethtool --coalesce eth0' \
-		-o match:"adaptive-tx 'on'" \
+		-o match:"adaptive-tx on" \
 		${EXECUTOR}
 }
 
@@ -326,7 +326,7 @@ up_coalesce_pkt_rate_low_body() {
 	export IFACE="eth0" PHASE="up" IF_ETHTOOL_COALESCE_PKT_RATE_LOW="1024" MOCK="echo"
 	atf_check -s exit:0 \
 		-o match:'ethtool --coalesce eth0' \
-		-o match:"pkt-rate-low '1024'" \
+		-o match:"pkt-rate-low 1024" \
 		${EXECUTOR}
 }
 
@@ -334,7 +334,7 @@ up_coalesce_pkt_rate_high_body() {
 	export IFACE="eth0" PHASE="up" IF_ETHTOOL_COALESCE_PKT_RATE_HIGH="1024" MOCK="echo"
 	atf_check -s exit:0 \
 		-o match:'ethtool --coalesce eth0' \
-		-o match:"pkt-rate-high '1024'" \
+		-o match:"pkt-rate-high 1024" \
 		${EXECUTOR}
 }
 
@@ -342,7 +342,7 @@ up_coalesce_sample_interval_body() {
 	export IFACE="eth0" PHASE="up" IF_ETHTOOL_COALESCE_SAMPLE_INTERVAL="1024" MOCK="echo"
 	atf_check -s exit:0 \
 		-o match:'ethtool --coalesce eth0' \
-		-o match:"sample-interval '1024'" \
+		-o match:"sample-interval 1024" \
 		${EXECUTOR}
 }
 
@@ -350,7 +350,7 @@ up_coalesce_stats_block_usecs_body() {
 	export IFACE="eth0" PHASE="up" IF_ETHTOOL_COALESCE_STATS_BLOCK_USECS="1024" MOCK="echo"
 	atf_check -s exit:0 \
 		-o match:'ethtool --coalesce eth0' \
-		-o match:"stats-block-usecs '1024'" \
+		-o match:"stats-block-usecs 1024" \
 		${EXECUTOR}
 }
 
@@ -358,7 +358,7 @@ up_coalesce_rx_frames_body() {
 	export IFACE="eth0" PHASE="up" IF_ETHTOOL_COALESCE_RX_FRAMES="1024" MOCK="echo"
 	atf_check -s exit:0 \
 		-o match:'ethtool --coalesce eth0' \
-		-o match:"rx-frames '1024'" \
+		-o match:"rx-frames 1024" \
 		${EXECUTOR}
 }
 
@@ -366,7 +366,7 @@ up_coalesce_rx_frames_low_body() {
 	export IFACE="eth0" PHASE="up" IF_ETHTOOL_COALESCE_RX_FRAMES_LOW="1024" MOCK="echo"
 	atf_check -s exit:0 \
 		-o match:'ethtool --coalesce eth0' \
-		-o match:"rx-frames-low '1024'" \
+		-o match:"rx-frames-low 1024" \
 		${EXECUTOR}
 }
 
@@ -374,7 +374,7 @@ up_coalesce_rx_frames_irq_body() {
 	export IFACE="eth0" PHASE="up" IF_ETHTOOL_COALESCE_RX_FRAMES_IRQ="1024" MOCK="echo"
 	atf_check -s exit:0 \
 		-o match:'ethtool --coalesce eth0' \
-		-o match:"rx-frames-irq '1024'" \
+		-o match:"rx-frames-irq 1024" \
 		${EXECUTOR}
 }
 
@@ -382,7 +382,7 @@ up_coalesce_rx_frames_high_body() {
 	export IFACE="eth0" PHASE="up" IF_ETHTOOL_COALESCE_RX_FRAMES_HIGH="1024" MOCK="echo"
 	atf_check -s exit:0 \
 		-o match:'ethtool --coalesce eth0' \
-		-o match:"rx-frames-high '1024'" \
+		-o match:"rx-frames-high 1024" \
 		${EXECUTOR}
 }
 
@@ -390,7 +390,7 @@ up_coalesce_rx_usecs_body() {
 	export IFACE="eth0" PHASE="up" IF_ETHTOOL_COALESCE_RX_USECS="1024" MOCK="echo"
 	atf_check -s exit:0 \
 		-o match:'ethtool --coalesce eth0' \
-		-o match:"rx-usecs '1024'" \
+		-o match:"rx-usecs 1024" \
 		${EXECUTOR}
 }
 
@@ -398,7 +398,7 @@ up_coalesce_rx_usecs_low_body() {
 	export IFACE="eth0" PHASE="up" IF_ETHTOOL_COALESCE_RX_USECS_LOW="1024" MOCK="echo"
 	atf_check -s exit:0 \
 		-o match:'ethtool --coalesce eth0' \
-		-o match:"rx-usecs-low '1024'" \
+		-o match:"rx-usecs-low 1024" \
 		${EXECUTOR}
 }
 
@@ -406,7 +406,7 @@ up_coalesce_rx_usecs_irq_body() {
 	export IFACE="eth0" PHASE="up" IF_ETHTOOL_COALESCE_RX_USECS_IRQ="1024" MOCK="echo"
 	atf_check -s exit:0 \
 		-o match:'ethtool --coalesce eth0' \
-		-o match:"rx-usecs-irq '1024'" \
+		-o match:"rx-usecs-irq 1024" \
 		${EXECUTOR}
 }
 
@@ -414,7 +414,7 @@ up_coalesce_rx_usecs_high_body() {
 	export IFACE="eth0" PHASE="up" IF_ETHTOOL_COALESCE_RX_USECS_HIGH="1024" MOCK="echo"
 	atf_check -s exit:0 \
 		-o match:'ethtool --coalesce eth0' \
-		-o match:"rx-usecs-high '1024'" \
+		-o match:"rx-usecs-high 1024" \
 		${EXECUTOR}
 }
 
@@ -422,7 +422,7 @@ up_coalesce_tx_frames_body() {
 	export IFACE="eth0" PHASE="up" IF_ETHTOOL_COALESCE_TX_FRAMES="1024" MOCK="echo"
 	atf_check -s exit:0 \
 		-o match:'ethtool --coalesce eth0' \
-		-o match:"tx-frames '1024'" \
+		-o match:"tx-frames 1024" \
 		${EXECUTOR}
 }
 
@@ -430,7 +430,7 @@ up_coalesce_tx_frames_low_body() {
 	export IFACE="eth0" PHASE="up" IF_ETHTOOL_COALESCE_TX_FRAMES_LOW="1024" MOCK="echo"
 	atf_check -s exit:0 \
 		-o match:'ethtool --coalesce eth0' \
-		-o match:"tx-frames-low '1024'" \
+		-o match:"tx-frames-low 1024" \
 		${EXECUTOR}
 }
 
@@ -438,7 +438,7 @@ up_coalesce_tx_frames_irq_body() {
 	export IFACE="eth0" PHASE="up" IF_ETHTOOL_COALESCE_TX_FRAMES_IRQ="1024" MOCK="echo"
 	atf_check -s exit:0 \
 		-o match:'ethtool --coalesce eth0' \
-		-o match:"tx-frames-irq '1024'" \
+		-o match:"tx-frames-irq 1024" \
 		${EXECUTOR}
 }
 
@@ -446,7 +446,7 @@ up_coalesce_tx_frames_high_body() {
 	export IFACE="eth0" PHASE="up" IF_ETHTOOL_COALESCE_TX_FRAMES_HIGH="1024" MOCK="echo"
 	atf_check -s exit:0 \
 		-o match:'ethtool --coalesce eth0' \
-		-o match:"tx-frames-high '1024'" \
+		-o match:"tx-frames-high 1024" \
 		${EXECUTOR}
 }
 
@@ -454,7 +454,7 @@ up_coalesce_tx_usecs_body() {
 	export IFACE="eth0" PHASE="up" IF_ETHTOOL_COALESCE_TX_USECS="1024" MOCK="echo"
 	atf_check -s exit:0 \
 		-o match:'ethtool --coalesce eth0' \
-		-o match:"tx-usecs '1024'" \
+		-o match:"tx-usecs 1024" \
 		${EXECUTOR}
 }
 
@@ -462,7 +462,7 @@ up_coalesce_tx_usecs_low_body() {
 	export IFACE="eth0" PHASE="up" IF_ETHTOOL_COALESCE_TX_USECS_LOW="1024" MOCK="echo"
 	atf_check -s exit:0 \
 		-o match:'ethtool --coalesce eth0' \
-		-o match:"tx-usecs-low '1024'" \
+		-o match:"tx-usecs-low 1024" \
 		${EXECUTOR}
 }
 
@@ -470,7 +470,7 @@ up_coalesce_tx_usecs_irq_body() {
 	export IFACE="eth0" PHASE="up" IF_ETHTOOL_COALESCE_TX_USECS_IRQ="1024" MOCK="echo"
 	atf_check -s exit:0 \
 		-o match:'ethtool --coalesce eth0' \
-		-o match:"tx-usecs-irq '1024'" \
+		-o match:"tx-usecs-irq 1024" \
 		${EXECUTOR}
 }
 
@@ -478,6 +478,6 @@ up_coalesce_tx_usecs_high_body() {
 	export IFACE="eth0" PHASE="up" IF_ETHTOOL_COALESCE_TX_USECS_HIGH="1024" MOCK="echo"
 	atf_check -s exit:0 \
 		-o match:'ethtool --coalesce eth0' \
-		-o match:"tx-usecs-high '1024'" \
+		-o match:"tx-usecs-high 1024" \
 		${EXECUTOR}
 }

--- a/tests/linux/ethtool_test
+++ b/tests/linux/ethtool_test
@@ -14,7 +14,15 @@ tests_init \
 	up_autoneg_mask \
 	up_pause_autoneg \
 	up_pause_tx \
-	up_pause_rx
+	up_pause_rx \
+	up_offload_gro \
+	up_offload_gso \
+	up_offload_lro \
+	up_offload_rx \
+	up_offload_sg \
+	up_offload_tso \
+	up_offload_tx \
+	up_offload_ufo
 
 pre_up_msglvl_body() {
 	export IFACE="eth0" PHASE="pre-up" IF_ETHTOOL_MSGLVL="debug on" MOCK="echo"
@@ -125,5 +133,117 @@ up_pause_rx_body() {
 	atf_check -s exit:0 \
 		-o match:'ethtool --pause eth0' \
 		-o match:"rx 'off'" \
+		${EXECUTOR}
+}
+
+up_offload_gro_body() {
+	export IFACE="eth0" PHASE="up" IF_ETHTOOL_OFFLOAD_GRO="on" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --offload eth0' \
+		-o match:"gro 'on'" \
+		${EXECUTOR}
+
+	export IFACE="eth0" PHASE="up" IF_ETHTOOL_OFFLOAD_GRO="off" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --offload eth0' \
+		-o match:"gro 'off'" \
+		${EXECUTOR}
+}
+
+up_offload_gso_body() {
+	export IFACE="eth0" PHASE="up" IF_ETHTOOL_OFFLOAD_GSO="on" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --offload eth0' \
+		-o match:"gso 'on'" \
+		${EXECUTOR}
+
+	export IFACE="eth0" PHASE="up" IF_ETHTOOL_OFFLOAD_GSO="off" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --offload eth0' \
+		-o match:"gso 'off'" \
+		${EXECUTOR}
+}
+
+up_offload_lro_body() {
+	export IFACE="eth0" PHASE="up" IF_ETHTOOL_OFFLOAD_LRO="on" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --offload eth0' \
+		-o match:"lro 'on'" \
+		${EXECUTOR}
+
+	export IFACE="eth0" PHASE="up" IF_ETHTOOL_OFFLOAD_LRO="off" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --offload eth0' \
+		-o match:"lro 'off'" \
+		${EXECUTOR}
+}
+
+up_offload_rx_body() {
+	export IFACE="eth0" PHASE="up" IF_ETHTOOL_OFFLOAD_RX="on" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --offload eth0' \
+		-o match:"rx 'on'" \
+		${EXECUTOR}
+
+	export IFACE="eth0" PHASE="up" IF_ETHTOOL_OFFLOAD_RX="off" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --offload eth0' \
+		-o match:"rx 'off'" \
+		${EXECUTOR}
+}
+
+up_offload_sg_body() {
+	export IFACE="eth0" PHASE="up" IF_ETHTOOL_OFFLOAD_SG="on" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --offload eth0' \
+		-o match:"sg 'on'" \
+		${EXECUTOR}
+
+	export IFACE="eth0" PHASE="up" IF_ETHTOOL_OFFLOAD_SG="off" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --offload eth0' \
+		-o match:"sg 'off'" \
+		${EXECUTOR}
+}
+
+up_offload_tso_body() {
+	export IFACE="eth0" PHASE="up" IF_ETHTOOL_OFFLOAD_TSO="on" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --offload eth0' \
+		-o match:"tso 'on'" \
+		${EXECUTOR}
+
+	export IFACE="eth0" PHASE="up" IF_ETHTOOL_OFFLOAD_TSO="off" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --offload eth0' \
+		-o match:"tso 'off'" \
+		${EXECUTOR}
+}
+
+up_offload_tx_body() {
+	export IFACE="eth0" PHASE="up" IF_ETHTOOL_OFFLOAD_TX="on" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --offload eth0' \
+		-o match:"tx 'on'" \
+		${EXECUTOR}
+
+	export IFACE="eth0" PHASE="up" IF_ETHTOOL_OFFLOAD_TX="off" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --offload eth0' \
+		-o match:"tx 'off'" \
+		${EXECUTOR}
+}
+
+up_offload_ufo_body() {
+	export IFACE="eth0" PHASE="up" IF_ETHTOOL_OFFLOAD_UFO="on" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --offload eth0' \
+		-o match:"ufo 'on'" \
+		${EXECUTOR}
+
+	export IFACE="eth0" PHASE="up" IF_ETHTOOL_OFFLOAD_UFO="off" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --offload eth0' \
+		-o match:"ufo 'off'" \
 		${EXECUTOR}
 }

--- a/tests/linux/ethtool_test
+++ b/tests/linux/ethtool_test
@@ -11,7 +11,10 @@ tests_init \
 	up_wol \
 	up_wol_sopass \
 	up_autoneg_simple \
-	up_autoneg_mask
+	up_autoneg_mask \
+	up_pause_autoneg \
+	up_pause_tx \
+	up_pause_rx
 
 pre_up_msglvl_body() {
 	export IFACE="eth0" PHASE="pre-up" IF_ETHTOOL_MSGLVL="debug on" MOCK="echo"
@@ -80,5 +83,47 @@ up_autoneg_mask_body() {
 	atf_check -s exit:0 \
 		-o match:'ethtool --change eth0' \
 		-o match:'autoneg on advertise 1000/full' \
+		${EXECUTOR}
+}
+
+up_pause_autoneg_body() {
+	export IFACE="eth0" PHASE="up" IF_ETHTOOL_PAUSE_AUTONEG="on" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --pause eth0' \
+		-o match:"autoneg 'on'" \
+		${EXECUTOR}
+
+	export IFACE="eth0" PHASE="up" IF_ETHTOOL_PAUSE_AUTONEG="off" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --pause eth0' \
+		-o match:"autoneg 'off'" \
+		${EXECUTOR}
+}
+
+up_pause_tx_body() {
+	export IFACE="eth0" PHASE="up" IF_ETHTOOL_PAUSE_TX="on" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --pause eth0' \
+		-o match:"tx 'on'" \
+		${EXECUTOR}
+
+	export IFACE="eth0" PHASE="up" IF_ETHTOOL_PAUSE_TX="off" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --pause eth0' \
+		-o match:"tx 'off'" \
+		${EXECUTOR}
+}
+
+up_pause_rx_body() {
+	export IFACE="eth0" PHASE="up" IF_ETHTOOL_PAUSE_RX="on" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --pause eth0' \
+		-o match:"rx 'on'" \
+		${EXECUTOR}
+
+	export IFACE="eth0" PHASE="up" IF_ETHTOOL_PAUSE_RX="off" MOCK="echo"
+	atf_check -s exit:0 \
+		-o match:'ethtool --pause eth0' \
+		-o match:"rx 'off'" \
 		${EXECUTOR}
 }


### PR DESCRIPTION
Allow setting ethtool properties in the `ethtool-` namespace with the `ethtool` executor.  We also remap all relevant `ifupdown2` and Debian terms to their appropriate counterparts in the `ethtool-` namespace.

Closes #53.