### PR TITLE
inherit/template system improvements

### DIFF
--- a/cmd/ifquery.c
+++ b/cmd/ifquery.c
@@ -30,7 +30,7 @@ print_interface(struct lif_interface *iface)
 	if (iface->is_auto)
 		printf("auto %s\n", iface->ifname);
 
-	printf("iface %s\n", iface->ifname);
+	printf("%s %s\n", iface->is_template ? "template" : "iface", iface->ifname);
 
 	struct lif_node *iter;
 	LIF_DICT_FOREACH(iter, &iface->vars)

--- a/cmd/ifupdown.c
+++ b/cmd/ifupdown.c
@@ -97,7 +97,10 @@ bool
 skip_interface(struct lif_interface *iface, const char *ifname)
 {
 	if (iface->is_template)
+	{
 		fprintf(stderr, "%s: cannot change state on %s (template interface)\n", argv0, ifname);
+		return false;
+	}
 
 	if (exec_opts.force)
 		return false;

--- a/cmd/ifupdown.c
+++ b/cmd/ifupdown.c
@@ -96,6 +96,9 @@ acquire_state_lock(const char *state_path, const char *lifname)
 bool
 skip_interface(struct lif_interface *iface, const char *ifname)
 {
+	if (iface->is_template)
+		fprintf(stderr, "%s: cannot change state on %s (template interface)\n", argv0, ifname);
+
 	if (exec_opts.force)
 		return false;
 

--- a/dist/ifupdown-ng.conf.example
+++ b/dist/ifupdown-ng.conf.example
@@ -15,3 +15,11 @@ allow_addon_scripts = 1
 # to disable this setting in order to require inheritance from specified
 # templates.
 allow_any_iface_as_template = 1
+
+# implicit_template_conversion:
+# In some legacy configs, a template may be declared as an iface, and
+# ifupdown-ng automatically converts those declarations to a proper
+# template.  If this setting is disabled, inheritance will continue to
+# work against non-template interfaces without converting them to a
+# template.
+implicit_template_conversion = 1

--- a/dist/ifupdown-ng.conf.example
+++ b/dist/ifupdown-ng.conf.example
@@ -8,3 +8,10 @@
 # compatibility with legacy setups, and may be disabled for performance
 # improvements in setups where only ifupdown-ng executors are used.
 allow_addon_scripts = 1
+
+# allow_any_iface_as_template:
+# Enable any interface to act as a template for another interface.
+# This is presently the default, but is deprecated.  An admin may choose
+# to disable this setting in order to require inheritance from specified
+# templates.
+allow_any_iface_as_template = 1

--- a/doc/interfaces.scd
+++ b/doc/interfaces.scd
@@ -47,6 +47,10 @@ with an address of *203.0.113.2* and gateway of *203.0.113.1*.
 	associated with the declaration will be stored inside
 	_object_.
 
+*template* _object_
+	Begins a new declaration for _object_, like *iface*, except
+	that _object_ is defined as a *template*.
+
 # SUPPORTED KEYWORDS FOR OBJECT TRIPLES
 
 Any keyword may be used inside an interface declaration block, but
@@ -79,9 +83,10 @@ the system will only respond to certain keywords by default:
 	Interfaces associated with the parent are taken down at
 	the same time as the parent.
 
-*inherit* _interface_
-	Designates that the parent interface should inherit
-	configuration data from _interface_.
+*inherit* _object_
+	Designates that the configured interface should inherit
+	configuration data from _object_.  Normally _object_
+	must be a *template*.
 
 *use* _option_
 	Designates that an option should be used.  See _OPTIONS_

--- a/libifupdown/config-file.c
+++ b/libifupdown/config-file.c
@@ -45,6 +45,7 @@ set_bool_value(const char *key, const char *value, void *opaque)
 static struct lif_config_handler handlers[] = {
 	{"allow_addon_scripts", set_bool_value, &lif_config.allow_addon_scripts},
 	{"allow_any_iface_as_template", set_bool_value, &lif_config.allow_any_iface_as_template},
+	{"implicit_template_conversion", set_bool_value, &lif_config.implicit_template_conversion},
 };
 
 bool

--- a/libifupdown/config-file.c
+++ b/libifupdown/config-file.c
@@ -20,6 +20,7 @@
 
 struct lif_config_file lif_config = {
 	.allow_addon_scripts = true,
+	.allow_any_iface_as_template = true,
 };
 
 static bool
@@ -43,6 +44,7 @@ set_bool_value(const char *key, const char *value, void *opaque)
 
 static struct lif_config_handler handlers[] = {
 	{"allow_addon_scripts", set_bool_value, &lif_config.allow_addon_scripts},
+	{"allow_any_iface_as_template", set_bool_value, &lif_config.allow_any_iface_as_template},
 };
 
 bool

--- a/libifupdown/config-file.h
+++ b/libifupdown/config-file.h
@@ -21,6 +21,7 @@
 struct lif_config_file {
 	bool allow_addon_scripts;
 	bool allow_any_iface_as_template;
+	bool implicit_template_conversion;
 };
 
 extern struct lif_config_file lif_config;

--- a/libifupdown/config-file.h
+++ b/libifupdown/config-file.h
@@ -20,6 +20,7 @@
 
 struct lif_config_file {
 	bool allow_addon_scripts;
+	bool allow_any_iface_as_template;
 };
 
 extern struct lif_config_file lif_config;

--- a/libifupdown/interface-file.c
+++ b/libifupdown/interface-file.c
@@ -336,7 +336,9 @@ static const struct parser_keyword keywords[] = {
 	{"gateway", handle_gateway},
 	{"iface", handle_iface},
 	{"inherit", handle_inherit},
+	{"interface", handle_iface},
 	{"source", handle_source},
+	{"template", handle_iface},
 	{"use", handle_use},
 };
 

--- a/libifupdown/interface-file.c
+++ b/libifupdown/interface-file.c
@@ -236,6 +236,12 @@ handle_iface(struct lif_dict *collection, const char *filename, size_t lineno, c
 		return false;
 	}
 
+	/* mark the cur_iface as a template iface if `template` keyword
+	 * is used.
+	 */
+	if (!strcmp(token, "template"))
+		cur_iface->is_template = true;
+
 	/* in original ifupdown config, we can have "inet loopback"
 	 * or "inet dhcp" or such to designate hints.  lets pick up
 	 * those hints here.

--- a/libifupdown/interface-file.c
+++ b/libifupdown/interface-file.c
@@ -162,7 +162,9 @@ handle_auto(struct lif_dict *collection, const char *filename, size_t lineno, ch
 			return false;
 	}
 
-	cur_iface->is_auto = true;
+	if (!cur_iface->is_template)
+		cur_iface->is_auto = true;
+
 	return true;
 }
 
@@ -240,7 +242,10 @@ handle_iface(struct lif_dict *collection, const char *filename, size_t lineno, c
 	 * is used.
 	 */
 	if (!strcmp(token, "template"))
+	{
+		cur_iface->is_auto = false;
 		cur_iface->is_template = true;
+	}
 
 	/* in original ifupdown config, we can have "inet loopback"
 	 * or "inet dhcp" or such to designate hints.  lets pick up

--- a/libifupdown/interface.c
+++ b/libifupdown/interface.c
@@ -16,6 +16,7 @@
 #include <stdio.h>
 #include <string.h>
 #include "libifupdown/interface.h"
+#include "libifupdown/config-file.h"
 
 bool
 lif_address_parse(struct lif_address *address, const char *presentation)
@@ -237,6 +238,9 @@ lif_interface_collection_inherit(struct lif_interface *interface, struct lif_dic
 	struct lif_interface *parent = lif_interface_collection_find(collection, ifname);
 
 	if (parent == NULL)
+		return false;
+
+	if (!lif_config.allow_any_iface_as_template && !parent->is_template)
 		return false;
 
 	lif_dict_add(&interface->vars, "inherit", strdup(ifname));

--- a/libifupdown/interface.c
+++ b/libifupdown/interface.c
@@ -243,8 +243,9 @@ lif_interface_collection_inherit(struct lif_interface *interface, struct lif_dic
 	if (!lif_config.allow_any_iface_as_template && !parent->is_template)
 		return false;
 
-	/* explicitly convert any interface we are inheriting from into a template */
-	parent->is_template = true;
+	/* maybe convert any interface we are inheriting from into a template */
+	if (lif_config.implicit_template_conversion)
+		parent->is_template = true;
 
 	lif_dict_add(&interface->vars, "inherit", strdup(ifname));
 	interface->is_bond = parent->is_bond;

--- a/libifupdown/interface.c
+++ b/libifupdown/interface.c
@@ -243,6 +243,9 @@ lif_interface_collection_inherit(struct lif_interface *interface, struct lif_dic
 	if (!lif_config.allow_any_iface_as_template && !parent->is_template)
 		return false;
 
+	/* explicitly convert any interface we are inheriting from into a template */
+	parent->is_template = true;
+
 	lif_dict_add(&interface->vars, "inherit", strdup(ifname));
 	interface->is_bond = parent->is_bond;
 	interface->is_bridge = parent->is_bridge;

--- a/libifupdown/interface.h
+++ b/libifupdown/interface.h
@@ -50,6 +50,7 @@ struct lif_interface {
 	bool is_auto;
 	bool is_bridge;
 	bool is_bond;
+	bool is_template;
 
 	struct lif_dict vars;
 

--- a/libifupdown/lifecycle.c
+++ b/libifupdown/lifecycle.c
@@ -341,6 +341,9 @@ handle_dependents(const struct lif_execute_opts *opts, struct lif_interface *par
 bool
 lif_lifecycle_run(const struct lif_execute_opts *opts, struct lif_interface *iface, struct lif_dict *collection, struct lif_dict *state, const char *lifname, bool up)
 {
+	if (iface->is_template)
+		return false;
+
 	if (lifname == NULL)
 		lifname = iface->ifname;
 


### PR DESCRIPTION
Per yesterday's discussion:

* Add `interface` and `template` keywords as alternatives to `iface`.
* If an interface is declared using the `template` keyword, it will be flagged as a template.
* Templates do not allow state changes: you cannot `ifup` or `ifdown` a template directly, nor can they be marked as `auto`.
* Any interface that is referenced using `inherit` is automatically converted into a template.
* A config option is added that, if disabled, would require `inherit` keyword to be used only with interfaces declared as a template.