### PR TITLE
Add support for veth interface pairs

### DIFF
--- a/doc/interfaces.scd
+++ b/doc/interfaces.scd
@@ -73,6 +73,13 @@ the system will only respond to certain keywords by default:
 *link-type* _link-type_
 	Denotes the link-type of the interface. When set to _dummy_,
 	the interface is created as a virtual dummy interfaces.
+	When set to _veth_ the interface is created as virtual veth
+	interface (pair).
+
+*veth-peer-name* _peer-name_
+	Denotes the name of the veth peer interfaces. If not set
+	the kernel will name the veth peer interface as _vethN_
+	with N being an integer number.
 
 *alias* _alias_
 	Sets the given alias on the interface.

--- a/executor-scripts/linux/link
+++ b/executor-scripts/linux/link
@@ -28,6 +28,17 @@ is_vlan() {
 }
 
 case "$PHASE" in
+depend)
+	# vlan-raw-device
+	if is_vlan; then
+		echo "$IF_VLAN_RAW_DEVICE"
+
+	# veth-peer-name
+	elif [ "${IF_LINK_TYPE}" = "veth" -a "${IF_VETH_PEER_NAME}" ]; then
+		echo "${IF_VETH_PEER_NAME}"
+	fi
+	;;
+
 create)
 	if [ "${IF_LINK_TYPE}" = "dummy" ]; then
 		if [ -d "/sys/class/net/${IFACE}" ]; then
@@ -92,11 +103,6 @@ destroy)
 		fi
 
 		${MOCK} ip link del "${IFACE}"
-	fi
-	;;
-depend)
-	if is_vlan; then
-		echo "$IF_VLAN_RAW_DEVICE"
 	fi
 	;;
 esac

--- a/executor-scripts/linux/link
+++ b/executor-scripts/linux/link
@@ -39,9 +39,18 @@ create)
 		fi
 
 		${MOCK} ip link add "${IFACE}" type dummy
-	fi
 
-	if is_vlan; then
+	elif [ "${IF_LINK_TYPE}" = "veth" ]; then
+		if [ ! -d "/sys/class/net/${IFACE}" ]; then
+			ARGS=""
+			if [ "${IF_VETH_PEER_NAME}" ]; then
+				ARGS="peer ${IF_VETH_PEER_NAME}"
+			fi
+
+			${MOCK} ip link add "${IFACE}" type veth ${ARGS}
+		fi
+
+	elif is_vlan; then
 		if [ -d "/sys/class/net/${IFACE}" ]; then
 			exit 0
 		fi
@@ -77,7 +86,7 @@ down)
 	${MOCK} ip link set down dev "${IFACE}"
 	;;
 destroy)
-	if [ "${IF_LINK_TYPE}" = "dummy" ] || is_vlan; then
+	if [ "${IF_LINK_TYPE}" = "dummy" ] || [ "${IF_LINK_TYPE}" = "veth" ] || is_vlan; then
 		if [ -z "${MOCK}" -a ! -d "/sys/class/net/${IFACE}" ]; then
 			exit 0
 		fi


### PR DESCRIPTION
This adds support for veth interface pairs as referenced #85 

An example config is

```
# veth_ext2int
auto veth_ext2int
iface veth_ext2int
        link-type veth
        mtu 1500
        veth-peer-name veth_int2ext
        vrf vrf_external

# veth_int2ext
auto veth_int2ext
iface veth_int2ext
        link-type veth
        mtu 1500
        veth-peer-name veth_ext2int
```

Currently both interfaces will resolve the pair as a dependency. I'm unsure if this is the best corse of action. The idea is to make sure the regardless which interface is ifup'd that the other one if configured as well.