### PR TITLE
static: always associate default routes with $IFACE

### DIFF
--- a/executor-scripts/linux/static
+++ b/executor-scripts/linux/static
@@ -27,7 +27,7 @@ configure_addresses() {
 configure_gateways() {
 	for i in $(ifquery -p gateway -i $INTERFACES_FILE $IFACE); do
 		addrfam=$(addr_family $i)
-		${MOCK} ip $addrfam route $1 default via $i $VRF_TABLE $METRIC
+		${MOCK} ip $addrfam route $1 default via $i $VRF_TABLE $METRIC dev $IFACE
 	done
 }
 

--- a/tests/linux/static_test
+++ b/tests/linux/static_test
@@ -11,8 +11,8 @@ up_body() {
 	atf_check -s exit:0 \
 		-o match:'addr add 203.0.113.2/24 dev eth0' \
 		-o match:'addr add 2001:db8:1000:2::2/64 dev eth0' \
-		-o match:'route add default via 203.0.113.1' \
-		-o match:'route add default via 2001:db8:1000:2::1' \
+		-o match:'route add default via 203.0.113.1 metric 1 dev eth0' \
+		-o match:'route add default via 2001:db8:1000:2::1 metric 1 dev eth0' \
 		${EXECUTOR}
 }
 
@@ -21,8 +21,8 @@ down_body() {
 	atf_check -s exit:0 \
 		-o match:'addr del 203.0.113.2/24 dev eth0' \
 		-o match:'addr del 2001:db8:1000:2::2/64 dev eth0' \
-		-o match:'route del default via 203.0.113.1' \
-		-o match:'route del default via 2001:db8:1000:2::1' \
+		-o match:'route del default via 203.0.113.1 metric 1 dev eth0' \
+		-o match:'route del default via 2001:db8:1000:2::1 metric 1 dev eth0' \
 		${EXECUTOR}
 }
 


### PR DESCRIPTION
Hetzner uses link-local addressing for their default IPv6 route,
accordingly we should specify the device a route is associated with
so that it will use the correct interface.

Thanks to Devin Brown for reporting this issue.