### PR TITLE
Expose all adresses and gateways as environment variables

### DIFF
--- a/executor-scripts/linux/static
+++ b/executor-scripts/linux/static
@@ -2,12 +2,13 @@
 
 set -e
 
-[ -z "$VERBOSE" ] || set -x
+[ -z "${VERBOSE}" ] || set -x
 
-[ -z "$IF_METRIC" ] && IF_METRIC="1"
-[ -n "$IF_VRF_TABLE" ] && VRF_TABLE="table $IF_VRF_TABLE"
-[ -n "$IF_VRF_MEMBER" ] && VRF_TABLE="vrf $IF_VRF_MEMBER"
-[ -n "$IF_METRIC" ] && METRIC="metric $IF_METRIC"
+[ -z "${IF_METRIC}" ] && IF_METRIC="1"
+[ -n "${IF_VRF_TABLE}" ] && VRF_TABLE="table ${IF_VRF_TABLE}"
+[ -n "${IF_VRF_MEMBER}" ] && VRF_TABLE="vrf ${IF_VRF_MEMBER}"
+[ -n "${IF_METRIC}" ] && METRIC="metric ${IF_METRIC}"
+
 
 addr_family() {
 	if [ "$1" != "${1#*[0-9].[0-9]}" ]; then
@@ -20,22 +21,22 @@ addr_family() {
 }
 
 configure_addresses() {
-	for i in $(ifquery -p address -i $INTERFACES_FILE $IFACE); do
-		addrfam=$(addr_family $i)
+	for addr in ${IF_ADDRESSES}; do
+		addrfam=$(addr_family ${addr})
 		if [ "${IF_POINT_TO_POINT}" -a "${addrfam}" = "-4" ]; then
 			PEER="peer ${IF_POINT_TO_POINT}"
 		else
 			PEER=""
 		fi
 
-		${MOCK} ip $addrfam addr $1 $i $PEER dev $IFACE
+		${MOCK} ip "${addrfam}" addr "${1}" "${addr}" ${PEER} dev "${IFACE}"
 	done
 }
 
 configure_gateways() {
-	for i in $(ifquery -p gateway -i $INTERFACES_FILE $IFACE); do
-		addrfam=$(addr_family $i)
-		${MOCK} ip $addrfam route $1 default via $i $VRF_TABLE $METRIC dev $IFACE
+	for gw in ${IF_GATEWAYS}; do
+		addrfam=$(addr_family ${gw})
+		${MOCK} ip "${addrfam}" route "${1}" default via "${gw}" ${VRF_TABLE} ${METRIC} dev "${IFACE}"
 	done
 }
 

--- a/executor-scripts/linux/static
+++ b/executor-scripts/linux/static
@@ -29,7 +29,16 @@ configure_addresses() {
 			PEER=""
 		fi
 
-		${MOCK} ip "${addrfam}" addr "${1}" "${addr}" ${PEER} dev "${IFACE}"
+		if [ -z "${MOCK}" -a "${1}" = "del" ]; then
+			# When having multiple addresses set from the same prefix they might/will(?) be configured
+			# as 'secondary' and implicitly removed when removing the non-secondary address. This
+			# leads ip complaining about not being able to remove the secondaries as they are already
+			# gone. So we ignore errors while deconfiguring addresses as they liked occur when removing
+			# a vanish address anyway.
+			${MOCK} ip "${addrfam}" addr "${1}" "${addr}" ${PEER} dev "${IFACE}" 2>/dev/null
+		else
+			${MOCK} ip "${addrfam}" addr "${1}" "${addr}" ${PEER} dev "${IFACE}"
+		fi
 	done
 }
 

--- a/libifupdown/lifecycle.c
+++ b/libifupdown/lifecycle.c
@@ -122,7 +122,6 @@ append_to_buffer(char **buffer, size_t *buffer_len, char **end, const char *valu
 	/* Make sure there is enough room to add the value to the buffer */
 	if (*buffer_len < strlen (*buffer) + value_len + 2)
 	{
-		printf ("Doubling buffer...\n");
 		*buffer = realloc (*buffer, *buffer_len * 2);
 		if (*buffer == NULL)
 			/* XXX Here be dragons */

--- a/libifupdown/lifecycle.c
+++ b/libifupdown/lifecycle.c
@@ -131,7 +131,7 @@ append_to_buffer(char **buffer, size_t *buffer_len, char **end, const char *valu
 	}
 
 	/* Append value to buffer */
-	size_t printed = sprintf (*end, "%s ", value);
+	size_t printed = snprintf (*end, value_len + 2, "%s ", value);
 	if (printed < value_len + 1)
 		/* Here be dragons */
 		return false;

--- a/libifupdown/lifecycle.c
+++ b/libifupdown/lifecycle.c
@@ -231,6 +231,10 @@ build_environment(char **envp[], const struct lif_execute_opts *opts, const stru
 		lif_environment_push(envp, "IF_ADDRESSES", addresses);
 	if (gateways != NULL)
 		lif_environment_push(envp, "IF_GATEWAYS", gateways);
+
+	/* Clean up */
+	free (addresses);
+	free (gateways);
 }
 
 bool

--- a/libifupdown/version.c
+++ b/libifupdown/version.c
@@ -23,7 +23,8 @@ lif_common_version(void)
 {
 	printf("%s %s\n", PACKAGE_NAME, PACKAGE_VERSION);
 
-	printf("\nCopyright (c) 2020 Ariadne Conill <ariadne@dereferenced.org>\n\n");
+	printf("\nCopyright (c) 2020 Ariadne Conill <ariadne@dereferenced.org>\n");
+	printf("\nCopyright (c) 2020 Maximilian Wilhelm <max@sdn.clinic>\n\n");
 
 	printf("Permission to use, copy, modify, and/or distribute this software for any\n");
 	printf("purpose with or without fee is hereby granted, provided that the above\n");

--- a/tests/linux/static_test
+++ b/tests/linux/static_test
@@ -2,7 +2,6 @@
 
 . $(atf_get_srcdir)/../test_env.sh
 EXECUTOR="$(atf_get_srcdir)/../../executor-scripts/linux/static"
-FIXTURES="$(atf_get_srcdir)/../fixtures"
 
 tests_init \
 	up \
@@ -14,7 +13,8 @@ tests_init \
 	metric_down
 
 up_body() {
-	export IFACE=eth0 PHASE=up MOCK=echo INTERFACES_FILE="$FIXTURES/static-eth0.interfaces"
+	export IFACE=eth0 PHASE=up MOCK=echo IF_ADDRESSES="203.0.113.2/24 2001:db8:1000:2::2/64" \
+		IF_GATEWAYS="203.0.113.1 2001:db8:1000:2::1"
 	atf_check -s exit:0 \
 		-o match:'addr add 203.0.113.2/24 dev eth0' \
 		-o match:'addr add 2001:db8:1000:2::2/64 dev eth0' \
@@ -24,8 +24,8 @@ up_body() {
 }
 
 up_ptp_body() {
-	export IFACE=eth0 PHASE=up MOCK=echo INTERFACES_FILE="$FIXTURES/static-eth0-ptp.interfaces" \
-		IF_POINT_TO_POINT="192.0.2.1"
+	export IFACE=eth0 PHASE=up MOCK=echo IF_ADDRESSES="203.0.113.2/32 2001:db8:1000:2::2/64" \
+		IF_GATEWAYS="192.0.2.1 2001:db8:1000:2::1" IF_POINT_TO_POINT="192.0.2.1"
 	atf_check -s exit:0 \
 		-o match:'addr add 203.0.113.2/32 peer 192.0.2.1 dev eth0' \
 		-o match:'route add default via 192.0.2.1 metric 1 dev eth0' \
@@ -35,7 +35,8 @@ up_ptp_body() {
 }
 
 down_body() {
-	export IFACE=eth0 PHASE=down MOCK=echo INTERFACES_FILE="$FIXTURES/static-eth0.interfaces"
+	export IFACE=eth0 PHASE=down MOCK=echo IF_ADDRESSES="203.0.113.2/24 2001:db8:1000:2::2/64" \
+		IF_GATEWAYS="203.0.113.1 2001:db8:1000:2::1"
 	atf_check -s exit:0 \
 		-o match:'addr del 203.0.113.2/24 dev eth0' \
 		-o match:'addr del 2001:db8:1000:2::2/64 dev eth0' \
@@ -45,32 +46,28 @@ down_body() {
 }
 
 vrf_up_body() {
-	export IFACE=vrf-red PHASE=up MOCK=echo INTERFACES_FILE="$FIXTURES/vrf.interfaces" \
-		IF_VRF_TABLE=1
+	export IFACE=vrf-red PHASE=up MOCK=echo IF_GATEWAYS=203.0.113.2 IF_VRF_TABLE=1
 	atf_check -s exit:0 \
 		-o match:'route add default via 203.0.113.2 table 1' \
 		${EXECUTOR}
 }
 
 vrf_down_body() {
-	export IFACE=vrf-red PHASE=down MOCK=echo INTERFACES_FILE="$FIXTURES/vrf.interfaces" \
-		IF_VRF_TABLE=1
+	export IFACE=vrf-red PHASE=down MOCK=echo IF_GATEWAYS=203.0.113.2 IF_VRF_TABLE=1
 	atf_check -s exit:0 \
 		-o match:'route del default via 203.0.113.2 table 1' \
 		${EXECUTOR}
 }
 
 metric_up_body() {
-	export IFACE=vrf-red PHASE=up MOCK=echo INTERFACES_FILE="$FIXTURES/vrf.interfaces" \
-		IF_VRF_TABLE=1 IF_METRIC=20
+	export IFACE=vrf-red PHASE=up MOCK=echo IF_GATEWAYS=203.0.113.2 IF_VRF_TABLE=1 IF_METRIC=20
 	atf_check -s exit:0 \
 		-o match:'route add default via 203.0.113.2 table 1 metric 20' \
 		${EXECUTOR}
 }
 
 metric_down_body() {
-	export IFACE=vrf-red PHASE=down MOCK=echo INTERFACES_FILE="$FIXTURES/vrf.interfaces" \
-		IF_VRF_TABLE=1 IF_METRIC=20
+	export IFACE=vrf-red PHASE=down MOCK=echo IF_GATEWAYS=203.0.113.2 IF_VRF_TABLE=1 IF_METRIC=20
 	atf_check -s exit:0 \
 		-o match:'route del default via 203.0.113.2 table 1 metric 20' \
 		${EXECUTOR}


### PR DESCRIPTION
 Gather all IP addresses and gateways and expose them as `IF_ADDRESSES` and
`IF_GATEWAYS` environment variables to executors. This eliminates the need
to run ifquery from execuctors which would have to parse the config file
again on every run.