### PR TITLE
Always convert netmasks to CIDR when configuring interfaces

### DIFF
--- a/libifupdown/dict.c
+++ b/libifupdown/dict.c
@@ -86,7 +86,7 @@ lif_dict_add_once(struct lif_dict *dict, const char *key, void *data,
 }
 
 struct lif_dict_entry *
-lif_dict_find(struct lif_dict *dict, const char *key)
+lif_dict_find(const struct lif_dict *dict, const char *key)
 {
 	struct lif_node *iter;
 
@@ -102,7 +102,7 @@ lif_dict_find(struct lif_dict *dict, const char *key)
 }
 
 struct lif_list *
-lif_dict_find_all(struct lif_dict *dict, const char *key)
+lif_dict_find_all(const struct lif_dict *dict, const char *key)
 {
 	struct lif_list *entries = calloc(1, sizeof *entries);
 	struct lif_node *iter;

--- a/libifupdown/dict.h
+++ b/libifupdown/dict.h
@@ -44,8 +44,8 @@ extern void lif_dict_init(struct lif_dict *dict);
 extern void lif_dict_fini(struct lif_dict *dict);
 extern struct lif_dict_entry *lif_dict_add(struct lif_dict *dict, const char *key, void *data);
 extern struct lif_dict_entry *lif_dict_add_once(struct lif_dict *dict, const char *key, void *data, lif_dict_cmp_t compar);
-extern struct lif_dict_entry *lif_dict_find(struct lif_dict *dict, const char *key);
-extern struct lif_list *lif_dict_find_all(struct lif_dict *dict, const char *key);
+extern struct lif_dict_entry *lif_dict_find(const struct lif_dict *dict, const char *key);
+extern struct lif_list *lif_dict_find_all(const struct lif_dict *dict, const char *key);
 extern void lif_dict_delete(struct lif_dict *dict, const char *key);
 extern void lif_dict_delete_entry(struct lif_dict *dict, struct lif_dict_entry *entry);
 

--- a/libifupdown/interface.c
+++ b/libifupdown/interface.c
@@ -84,7 +84,7 @@ count_set_bits(const char *netmask)
 }
 
 bool
-lif_address_format_cidr(struct lif_interface *iface, struct lif_dict_entry *entry, char *buf, size_t buflen)
+lif_address_format_cidr(const struct lif_interface *iface, struct lif_dict_entry *entry, char *buf, size_t buflen)
 {
 	struct lif_address *addr = entry->data;
 	size_t orig_netmask = addr->netmask;

--- a/libifupdown/interface.h
+++ b/libifupdown/interface.h
@@ -67,7 +67,7 @@ struct lif_interface {
 
 extern bool lif_address_parse(struct lif_address *address, const char *presentation);
 extern bool lif_address_unparse(const struct lif_address *address, char *buf, size_t buflen, bool with_netmask);
-extern bool lif_address_format_cidr(struct lif_interface *iface, struct lif_dict_entry *entry, char *buf, size_t buflen);
+extern bool lif_address_format_cidr(const struct lif_interface *iface, struct lif_dict_entry *entry, char *buf, size_t buflen);
 
 extern void lif_interface_init(struct lif_interface *interface, const char *ifname);
 extern bool lif_interface_address_add(struct lif_interface *interface, const char *address);

--- a/libifupdown/interface.h
+++ b/libifupdown/interface.h
@@ -32,9 +32,6 @@ struct lif_address {
 	int domain;
 };
 
-extern bool lif_address_parse(struct lif_address *address, const char *presentation);
-extern bool lif_address_unparse(const struct lif_address *address, char *buf, size_t buflen, bool with_netmask);
-
 /*
  * Interfaces are contained in a dictionary, with the interfaces mapped by
  * interface name to their `struct lif_interface`.
@@ -67,6 +64,10 @@ struct lif_interface {
 
 #define LIF_INTERFACE_COLLECTION_FOREACH_SAFE(iter, iter_next, collection) \
 	LIF_DICT_FOREACH_SAFE((iter), (iter_next), (collection))
+
+extern bool lif_address_parse(struct lif_address *address, const char *presentation);
+extern bool lif_address_unparse(const struct lif_address *address, char *buf, size_t buflen, bool with_netmask);
+extern bool lif_address_format_cidr(struct lif_interface *iface, struct lif_dict_entry *entry, char *buf, size_t buflen);
 
 extern void lif_interface_init(struct lif_interface *interface, const char *ifname);
 extern bool lif_interface_address_add(struct lif_interface *interface, const char *address);

--- a/libifupdown/lifecycle.c
+++ b/libifupdown/lifecycle.c
@@ -174,14 +174,13 @@ build_environment(char **envp[], const struct lif_execute_opts *opts, const stru
 
 	LIF_DICT_FOREACH(iter, &iface->vars)
 	{
-		const struct lif_dict_entry *entry = iter->data;
+		struct lif_dict_entry *entry = iter->data;
 
 		if (!strcmp(entry->key, "address"))
 		{
-			struct lif_address *addr = entry->data;
 			char addrbuf[4096];
 
-			if (!lif_address_unparse(addr, addrbuf, sizeof addrbuf, true))
+			if (!lif_address_format_cidr(iface, entry, addrbuf, sizeof(addrbuf)))
 				continue;
 
 			/* Append address to buffer */


### PR DESCRIPTION
When setting up an interface like

```
iface eth0
    address 192.0.2.1
    netmask 255.255.255.128
```

ifupdown-ng did not configure this interface correctly since #100 was merged as the netmask was not given to the executor. The PR fixes that behavirour and computes a CIDR netmask if necessary.
