### PR TITLE
refactor config file management

### DIFF
--- a/cmd/ifquery.c
+++ b/cmd/ifquery.c
@@ -247,6 +247,9 @@ ifquery_main(int argc, char *argv[])
 {
 	struct lif_dict state = {};
 	struct lif_dict collection = {};
+	struct lif_interface_file_parse_state parse_state = {
+		.collection = &collection,
+	};
 
 	lif_interface_collection_init(&collection);
 
@@ -256,7 +259,7 @@ ifquery_main(int argc, char *argv[])
 		return EXIT_FAILURE;
 	}
 
-	if (!lif_interface_file_parse(&collection, exec_opts.interfaces_file))
+	if (!lif_interface_file_parse(&parse_state, exec_opts.interfaces_file))
 	{
 		fprintf(stderr, "%s: could not parse %s\n", argv0, exec_opts.interfaces_file);
 		return EXIT_FAILURE;

--- a/cmd/ifupdown.c
+++ b/cmd/ifupdown.c
@@ -237,6 +237,9 @@ ifupdown_main(int argc, char *argv[])
 
 	struct lif_dict state = {};
 	struct lif_dict collection = {};
+	struct lif_interface_file_parse_state parse_state = {
+		.collection = &collection,
+	};
 
 	lif_interface_collection_init(&collection);
 
@@ -246,7 +249,7 @@ ifupdown_main(int argc, char *argv[])
 		return EXIT_FAILURE;
 	}
 
-	if (!lif_interface_file_parse(&collection, exec_opts.interfaces_file))
+	if (!lif_interface_file_parse(&parse_state, exec_opts.interfaces_file))
 	{
 		fprintf(stderr, "%s: could not parse %s\n", argv0, exec_opts.interfaces_file);
 		return EXIT_FAILURE;

--- a/doc/interfaces.scd
+++ b/doc/interfaces.scd
@@ -47,6 +47,12 @@ with an address of *203.0.113.2* and gateway of *203.0.113.1*.
 	associated with the declaration will be stored inside
 	_object_.
 
+*source* _filename_
+	Includes the file _filename_ as configuration data.
+
+*source-directory* _directory_
+	Includes the files in _directory_ as configuration data.
+
 *template* _object_
 	Begins a new declaration for _object_, like *iface*, except
 	that _object_ is defined as a *template*.

--- a/libifupdown/interface-file.c
+++ b/libifupdown/interface-file.c
@@ -196,8 +196,6 @@ handle_gateway(struct lif_interface_file_parse_state *state, char *token, char *
 static bool
 handle_generic(struct lif_interface_file_parse_state *state, char *token, char *bufp)
 {
-	(void) state;
-
 	if (state->cur_iface == NULL)
 		return true;
 

--- a/libifupdown/interface-file.h
+++ b/libifupdown/interface-file.h
@@ -23,9 +23,10 @@
 struct lif_interface_file_parse_state {
 	struct lif_interface *cur_iface;
 	struct lif_dict *collection;
-	struct lif_dict *loaded;
 	const char *cur_filename;
 	size_t cur_lineno;
+
+	struct lif_dict loaded;
 };
 
 extern bool lif_interface_file_parse(struct lif_interface_file_parse_state *state, const char *filename);

--- a/libifupdown/interface-file.h
+++ b/libifupdown/interface-file.h
@@ -18,7 +18,16 @@
 
 #include <stdbool.h>
 #include "libifupdown/interface.h"
+#include "libifupdown/dict.h"
 
-extern bool lif_interface_file_parse(struct lif_dict *collection, const char *filename);
+struct lif_interface_file_parse_state {
+	struct lif_interface *cur_iface;
+	struct lif_dict *collection;
+	struct lif_dict *loaded;
+	const char *cur_filename;
+	size_t cur_lineno;
+};
+
+extern bool lif_interface_file_parse(struct lif_interface_file_parse_state *state, const char *filename);
 
 #endif


### PR DESCRIPTION
- [x] Break cycles using a dictionary instead of a naive comparison (closes #105).
- [x] Encapsulate global `cur_iface` into `lif_interface_file_parse_state`.
- [x] Implement `source-directory`.