### PR TITLE
dhcp hostname normalization

### DIFF
--- a/dist/ifupdown-ng.conf.example
+++ b/dist/ifupdown-ng.conf.example
@@ -24,3 +24,10 @@ allow_any_iface_as_template = 1
 # work against non-template interfaces without converting them to a
 # template.  Valid values are 0 and 1, the default is 1.
 implicit_template_conversion = 1
+
+# use_hostname_for_dhcp:
+# Automatically learn the hostname property, used for DHCP configuration
+# by querying the system hostname using uname(2).  This is basically
+# equivalent to `hostname $(hostname)` without having to specify any
+# configuration.  Valid values are 0 and 1, the default is 1.
+use_hostname_for_dhcp = 1

--- a/doc/ADMIN-GUIDE.md
+++ b/doc/ADMIN-GUIDE.md
@@ -67,6 +67,11 @@ Currently the following settings are supported in
   interfaces without converting them to a template. Valid values
   are `0` and `1`, the default is `1`.
 
+* `use_hostname_for_dhcp`: A common configuration pattern with DHCP
+  interfaces is to use `hostname $(hostname)`.  If this setting is
+  enabled, the `hostname` property will default to the system
+  hostname.  Valid values are `0` and `1`, the default is `1`.
+
 ## Interface Configuration
 
 ### Basic Configuration

--- a/libifupdown/config-file.c
+++ b/libifupdown/config-file.c
@@ -22,6 +22,7 @@ struct lif_config_file lif_config = {
 	.allow_addon_scripts = true,
 	.allow_any_iface_as_template = true,
 	.implicit_template_conversion = true,
+	.use_hostname_for_dhcp = true,
 };
 
 static bool
@@ -47,6 +48,7 @@ static struct lif_config_handler handlers[] = {
 	{"allow_addon_scripts", set_bool_value, &lif_config.allow_addon_scripts},
 	{"allow_any_iface_as_template", set_bool_value, &lif_config.allow_any_iface_as_template},
 	{"implicit_template_conversion", set_bool_value, &lif_config.implicit_template_conversion},
+	{"use_hostname_for_dhcp", set_bool_value, &lif_config.use_hostname_for_dhcp},
 };
 
 bool

--- a/libifupdown/config-file.h
+++ b/libifupdown/config-file.h
@@ -22,6 +22,7 @@ struct lif_config_file {
 	bool allow_addon_scripts;
 	bool allow_any_iface_as_template;
 	bool implicit_template_conversion;
+	bool use_hostname_for_dhcp;
 };
 
 extern struct lif_config_file lif_config;

--- a/libifupdown/interface-file.c
+++ b/libifupdown/interface-file.c
@@ -222,6 +222,24 @@ handle_generic(struct lif_interface_file_parse_state *state, char *token, char *
 	return true;
 }
 
+static bool
+handle_hostname(struct lif_interface_file_parse_state *state, char *token, char *bufp)
+{
+	char *hostname = lif_next_token(&bufp);
+
+	if (state->cur_iface == NULL)
+	{
+		report_error(state, "%s '%s' without interface", token, hostname);
+		/* Ignore this hostname, but don't fail hard */
+		return true;
+	}
+
+	lif_dict_delete(&state->cur_iface->vars, token);
+	lif_dict_add(&state->cur_iface->vars, token, strdup(hostname));
+
+	return true;
+}
+
 static bool handle_inherit(struct lif_interface_file_parse_state *state, char *token, char *bufp);
 
 static bool
@@ -408,6 +426,7 @@ static const struct parser_keyword keywords[] = {
 	{"address", handle_address},
 	{"auto", handle_auto},
 	{"gateway", handle_gateway},
+	{"hostname", handle_hostname},
 	{"iface", handle_iface},
 	{"inherit", handle_inherit},
 	{"interface", handle_iface},

--- a/libifupdown/interface.c
+++ b/libifupdown/interface.c
@@ -16,6 +16,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <sys/utsname.h>
 #include "libifupdown/interface.h"
 #include "libifupdown/config-file.h"
 
@@ -121,6 +122,13 @@ lif_interface_init(struct lif_interface *interface, const char *ifname)
 	/* keep the 'vlan' executor as a config hint for backwards compatibility */
 	if (strchr(ifname, '.') != NULL)
 		lif_interface_use_executor(interface, "vlan");
+
+	/* learn a reasonable default hostname */
+	struct utsname un;
+	if (uname(&un) < 0)
+		return;
+
+	lif_dict_add(&interface->vars, "hostname", strdup(un.nodename));
 }
 
 bool

--- a/libifupdown/interface.c
+++ b/libifupdown/interface.c
@@ -123,6 +123,9 @@ lif_interface_init(struct lif_interface *interface, const char *ifname)
 	if (strchr(ifname, '.') != NULL)
 		lif_interface_use_executor(interface, "vlan");
 
+	if (!lif_config.use_hostname_for_dhcp)
+		return;
+
 	/* learn a reasonable default hostname */
 	struct utsname un;
 	if (uname(&un) < 0)


### PR DESCRIPTION
This improves upon the `hostname $(hostname)` stuff by simply learning the hostname at interface creation time using uname(2). Closes #74.