### PR TITLE
guard auto and explicitly configured interfaces from inappropriate deconfiguration

### DIFF
--- a/cmd/ifquery.c
+++ b/cmd/ifquery.c
@@ -182,7 +182,8 @@ list_state(struct lif_dict *state, struct match_options *opts)
 		if (listing_running)
 			printf("%s\n", entry->key);
 		else
-			printf("%s=%s %zu\n", entry->key, rec->mapped_if, rec->refcount);
+			printf("%s=%s %zu%s\n", entry->key, rec->mapped_if, rec->refcount,
+			       rec->is_explicit ? " explicit" : "");
 	}
 }
 

--- a/cmd/ifupdown.c
+++ b/cmd/ifupdown.c
@@ -140,7 +140,7 @@ skip_interface(struct lif_interface *iface, const char *ifname)
 }
 
 bool
-change_interface(struct lif_interface *iface, struct lif_dict *collection, struct lif_dict *state, const char *ifname)
+change_interface(struct lif_interface *iface, struct lif_dict *collection, struct lif_dict *state, const char *ifname, bool update_state)
 {
 	int lockfd = acquire_state_lock(exec_opts.state_file, ifname);
 
@@ -178,6 +178,12 @@ change_interface(struct lif_interface *iface, struct lif_dict *collection, struc
 	if (lockfd != -1)
 		close(lockfd);
 
+	if (up && update_state)
+	{
+		iface->is_explicit = true;
+		lif_state_upsert(state, ifname, iface);
+	}
+
 	return true;
 }
 
@@ -202,7 +208,7 @@ change_auto_interfaces(struct lif_dict *collection, struct lif_dict *state, stru
 		    fnmatch(opts->include_pattern, iface->ifname, 0))
 			continue;
 
-		if (!change_interface(iface, collection, state, iface->ifname))
+		if (!change_interface(iface, collection, state, iface->ifname, false))
 			return false;
 	}
 
@@ -313,7 +319,7 @@ ifupdown_main(int argc, char *argv[])
 			iface = entry->data;
 		}
 
-		if (!change_interface(iface, &collection, &state, ifname))
+		if (!change_interface(iface, &collection, &state, ifname, true))
 			return update_state_file_and_exit(EXIT_FAILURE, &state);
 	}
 

--- a/libifupdown/interface-file.c
+++ b/libifupdown/interface-file.c
@@ -172,6 +172,9 @@ handle_auto(struct lif_interface_file_parse_state *state, char *token, char *buf
 	if (!state->cur_iface->is_template)
 		state->cur_iface->is_auto = true;
 
+	if (state->cur_iface->is_auto)
+		state->cur_iface->is_explicit = true;
+
 	return true;
 }
 

--- a/libifupdown/interface.c
+++ b/libifupdown/interface.c
@@ -223,6 +223,7 @@ lif_interface_collection_init(struct lif_dict *collection)
 	/* always enable loopback interface as part of a collection */
 	if_lo = lif_interface_collection_find(collection, "lo");
 	if_lo->is_auto = true;
+	if_lo->is_explicit = true;
 	lif_interface_use_executor(if_lo, "loopback");
 }
 

--- a/libifupdown/interface.h
+++ b/libifupdown/interface.h
@@ -50,6 +50,7 @@ struct lif_interface {
 	bool is_bond;
 	bool is_template;
 	bool is_pending;
+	bool is_explicit;
 
 	bool has_config_error;	/* error found in interface configuration */
 

--- a/libifupdown/lifecycle.c
+++ b/libifupdown/lifecycle.c
@@ -396,6 +396,15 @@ handle_dependents(const struct lif_execute_opts *opts, struct lif_interface *par
 			continue;
 		}
 
+		if (!up && iface->is_explicit)
+		{
+			if (opts->verbose)
+				fprintf(stderr, "ifupdown: skipping dependent interface %s (of %s) -- interface is marked as explicitly configured\n",
+					iface->ifname, parent->ifname);
+
+			continue;
+		}
+
 		if (opts->verbose)
 			fprintf(stderr, "ifupdown: changing state of dependent interface %s (of %s) to %s\n",
 				iface->ifname, parent->ifname, up ? "up" : "down");

--- a/libifupdown/state.c
+++ b/libifupdown/state.c
@@ -182,6 +182,7 @@ lif_state_sync(struct lif_dict *state, struct lif_dict *if_collection)
 		struct lif_interface *iface = lif_interface_collection_find(if_collection, rec->mapped_if);
 
 		iface->refcount = rec->refcount;
+		iface->is_explicit = rec->is_explicit;
 	}
 
 	return true;

--- a/libifupdown/state.c
+++ b/libifupdown/state.c
@@ -29,8 +29,13 @@ lif_state_read(struct lif_dict *state, FILE *fd)
 		char *bufp = linebuf;
 		char *ifname = lif_next_token(&bufp);
 		char *refcount = lif_next_token(&bufp);
+		char *explicit = lif_next_token(&bufp);
 		size_t rc = 1;
 		char *equals_p = strchr(linebuf, '=');
+		bool is_explicit = false;
+
+		if (*explicit)
+			is_explicit = true;
 
 		if (*refcount)
 		{
@@ -42,12 +47,12 @@ lif_state_read(struct lif_dict *state, FILE *fd)
 
 		if (equals_p == NULL)
 		{
-			lif_state_upsert(state, ifname, &(struct lif_interface){ .ifname = ifname, .refcount = rc });
+			lif_state_upsert(state, ifname, &(struct lif_interface){ .ifname = ifname, .refcount = rc, .is_explicit = is_explicit });
 			continue;
 		}
 
 		*equals_p++ = '\0';
-		lif_state_upsert(state, ifname, &(struct lif_interface){ .ifname = equals_p, .refcount = rc });
+		lif_state_upsert(state, ifname, &(struct lif_interface){ .ifname = equals_p, .refcount = rc, .is_explicit = is_explicit });
 	}
 
 	return true;
@@ -129,7 +134,8 @@ lif_state_write(const struct lif_dict *state, FILE *f)
 		struct lif_dict_entry *entry = iter->data;
 		struct lif_state_record *rec = entry->data;
 
-		fprintf(f, "%s=%s %zu\n", entry->key, rec->mapped_if, rec->refcount);
+		fprintf(f, "%s=%s %zu%s\n", entry->key, rec->mapped_if, rec->refcount,
+			rec->is_explicit ? " explicit" : "");
 	}
 }
 

--- a/libifupdown/state.c
+++ b/libifupdown/state.c
@@ -99,6 +99,7 @@ lif_state_upsert(struct lif_dict *state, const char *ifname, struct lif_interfac
 
 	rec->mapped_if = strdup(iface->ifname);
 	rec->refcount = iface->refcount;
+	rec->is_explicit = iface->is_explicit;
 
 	lif_dict_add(state, ifname, rec);
 }

--- a/libifupdown/state.c
+++ b/libifupdown/state.c
@@ -34,7 +34,7 @@ lif_state_read(struct lif_dict *state, FILE *fd)
 		char *equals_p = strchr(linebuf, '=');
 		bool is_explicit = false;
 
-		if (*explicit)
+		if (*explicit && !strcmp(explicit, "explicit"))
 			is_explicit = true;
 
 		if (*refcount)

--- a/libifupdown/state.h
+++ b/libifupdown/state.h
@@ -17,11 +17,14 @@
 #define LIBIFUPDOWN_STATE_H__GUARD
 
 #include <stdio.h>
+#include <stdbool.h>
 #include "libifupdown/interface.h"
 
 struct lif_state_record {
 	char *mapped_if;
 	size_t refcount;
+
+	bool is_explicit;
 };
 
 extern bool lif_state_read(struct lif_dict *state, FILE *f);


### PR DESCRIPTION
To protect against interfaces being deconfigured due to being a dependency, we mark `auto` and explicit (`ifup wlan0` for example) interfaces as such.

This resolves #115.