### PR TITLE
multicall: fix inappropriate use of getopt in the multicall stub

### DIFF
--- a/cmd/multicall.c
+++ b/cmd/multicall.c
@@ -73,6 +73,8 @@ applet_cmp(const void *a, const void *b)
 
 void multicall_usage(int status) __attribute__((noreturn));
 
+struct if_applet ifupdown_applet;
+
 int
 main(int argc, char *argv[])
 {
@@ -92,9 +94,11 @@ main(int argc, char *argv[])
 	}
 
 	self_applet = *app;
-	process_options(*app, argc, argv);
 
-	return (*app)->main(argc, argv);
+	if (self_applet != &ifupdown_applet)
+		process_options(*app, argc, argv);
+
+	return self_applet->main(argc, argv);
 }
 
 int
@@ -105,8 +109,6 @@ multicall_main(int argc, char *argv[])
 
 	return main(argc - 1, argv + 1);
 }
-
-struct if_applet ifupdown_applet;
 
 void
 multicall_usage(int status)

--- a/tests/Kyuafile
+++ b/tests/Kyuafile
@@ -2,6 +2,7 @@ syntax(2)
 
 test_suite('ifupdown-ng')
 
+atf_test_program{name='multicall_test'}
 atf_test_program{name='ifquery_test'}
 atf_test_program{name='ifup_test'}
 atf_test_program{name='ifdown_test'}

--- a/tests/multicall_test
+++ b/tests/multicall_test
@@ -1,0 +1,11 @@
+#!/usr/bin/env atf-sh
+
+. $(atf_get_srcdir)/test_env.sh
+
+tests_init \
+	regress_getopt
+
+regress_getopt_body() {
+	atf_check -e not-inline:'-F: applet not found' -o ignore -s exit:1 \
+		ifupdown ifquery -F
+}


### PR DESCRIPTION
Closes #126.