### PR TITLE
improve stanza merging by rewriting address properties as CIDR

### DIFF
--- a/libifupdown/interface-file.c
+++ b/libifupdown/interface-file.c
@@ -263,6 +263,12 @@ handle_iface(struct lif_interface_file_parse_state *state, char *token, char *bu
 		return true;
 	}
 
+	/* if we have a current interface, call lif_interface_finalize to finalize any
+	 * address properties by converting them to CIDR and flushing the netmask property.
+	 */
+	if (state->cur_iface != NULL)
+		lif_interface_finalize(state->cur_iface);
+
 	state->cur_iface = lif_interface_collection_find(state->collection, ifname);
 	if (state->cur_iface == NULL)
 	{
@@ -501,6 +507,11 @@ lif_interface_file_parse(struct lif_interface_file_parse_state *state, const cha
 	}
 
 	fclose(f);
+
+	/* finalize any open interface */
+	if (state->cur_iface != NULL)
+		lif_interface_finalize(state->cur_iface);
+
 	state->cur_filename = old_filename;
 	state->cur_lineno = old_lineno;
 	return true;

--- a/libifupdown/interface.h
+++ b/libifupdown/interface.h
@@ -75,6 +75,7 @@ extern bool lif_interface_address_add(struct lif_interface *interface, const cha
 extern void lif_interface_address_delete(struct lif_interface *interface, const char *address);
 extern void lif_interface_fini(struct lif_interface *interface);
 extern void lif_interface_use_executor(struct lif_interface *interface, const char *executor);
+extern void lif_interface_finalize(struct lif_interface *interface);
 
 extern void lif_interface_collection_init(struct lif_dict *collection);
 extern void lif_interface_collection_fini(struct lif_dict *collection);

--- a/tests/fixtures/stanza-merging.interfaces
+++ b/tests/fixtures/stanza-merging.interfaces
@@ -1,0 +1,14 @@
+# cidr and without-cidr should be equivalent
+iface cidr
+	address 203.0.113.1/32
+
+iface cidr
+	address 203.0.113.2/24
+
+iface without-cidr
+	address 203.0.113.1
+	netmask 32
+
+iface without-cidr
+	address 203.0.113.2
+	netmask 24

--- a/tests/ifquery_test
+++ b/tests/ifquery_test
@@ -38,7 +38,9 @@ tests_init \
 	allow_undefined_positive \
 	allow_undefined_negative \
 	default_netmask_v4 \
-	default_netmask_v6
+	default_netmask_v6 \
+	stanza_merging_with_cidr \
+	stanza_merging_without_cidr
 
 noargs_body() {
 	atf_check -s exit:1 -e ignore ifquery -S/dev/null
@@ -255,4 +257,18 @@ default_netmask_v6_body() {
 	atf_check -s exit:0 \
 		-o match:"2001:470:1f10::1/64" \
 		ifquery -i $FIXTURES/without-netmask.interfaces -p address v6
+}
+
+stanza_merging_with_cidr_body() {
+	atf_check -s exit:0 \
+		-o match:"203.0.113.1/32" \
+		-o match:"203.0.113.2/24" \
+		ifquery -i $FIXTURES/stanza-merging.interfaces -p address cidr
+}
+
+stanza_merging_without_cidr_body() {
+	atf_check -s exit:0 \
+		-o match:"203.0.113.1/32" \
+		-o match:"203.0.113.2/24" \
+		ifquery -i $FIXTURES/stanza-merging.interfaces -p address without-cidr
 }


### PR DESCRIPTION
By adding and using `lif_interface_finalize()`, we can rewrite stanza address properties to use CIDR notation as they are processed.

Closes #131.