### PR TITLE
Feature/forward executor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,8 @@ EXECUTOR_SCRIPTS_CORE ?= \
 	ipv6-ra \
 	static \
 	link \
-	ppp
+	ppp \
+	forward
 
 EXECUTOR_SCRIPTS_OPT ?= \
 	bridge \

--- a/Makefile
+++ b/Makefile
@@ -162,6 +162,7 @@ MANPAGES_5 = \
 	doc/interfaces-bond.5 \
 	doc/interfaces-batman.5 \
 	doc/interfaces-bridge.5 \
+	doc/interfaces-forward.5 \
 	doc/interfaces-ppp.5 \
 	doc/interfaces-vrf.5 \
 	doc/interfaces-vxlan.5 \

--- a/doc/interfaces-forward.scd
+++ b/doc/interfaces-forward.scd
@@ -1,0 +1,45 @@
+interfaces-forward(5)
+
+# NAME
+
+*interfaces-forward* - forwarding vocabulary for the interfaces(5) file format
+
+# DESCRIPTION
+
+Linux allows for configuration of IP packet forwarding behavior on a protocol
+and interface basis.  The following options allow for this configuration.
+
+# FORWARDING-RELATED OPTIONS
+
+*forward-ipv4* _yes|no_
+	Whether the interface should forward unicast IPv4 packets.
+
+*forward-ipv6* _yes|no_
+	Whether the interface should forward unicast IPv6 packets.
+
+*forward-ipv4-mc* _yes|no_
+	Whether the interface should forward multicast IPv4 packets.
+
+*forward-ipv6-mc* _yes|no_
+	Whether the interface should forward multicast IPv6 packets.
+
+# EXAMPLES
+
+The typical home router scenario will want to forward both IPv4 and IPv6
+packets:
+
+```
+iface WAN
+	use dhcp
+	forward-ipv4 yes
+	forward-ipv6 yes
+
+iface LAN
+	address 192.168.0.1/24
+	forward-ipv4 yes
+	forward-ipv6 yes
+```
+
+# AUTHORS
+
+Ariadne Conill <ariadne@dereferenced.org>

--- a/doc/interfaces-forward.scd
+++ b/doc/interfaces-forward.scd
@@ -11,6 +11,9 @@ and interface basis.  The following options allow for this configuration.
 
 # FORWARDING-RELATED OPTIONS
 
+The forward executor will only modify the sysctl configuration if these options
+are provided, otherwise other mechanisms such as /etc/sysctl.conf may be used.
+
 *forward-ipv4* _yes|no_
 	Whether the interface should forward unicast IPv4 packets.
 

--- a/doc/interfaces.scd
+++ b/doc/interfaces.scd
@@ -158,6 +158,9 @@ most common executors are:
 	Use a DHCP client to learn the IPv4 address of an
 	interface.
 
+*forward*
+	Configures forwarding settings on the interface.
+
 *loopback*
 	Designates the interface as a loopback device.
 

--- a/executor-scripts/linux/forward
+++ b/executor-scripts/linux/forward
@@ -15,3 +15,5 @@ yesno() {
 
 [ -n "$IF_FORWARD_IPV4_MC" ] && ${MOCK} /bin/sh -c "echo $(yesno $IF_FORWARD_IPV4_MC) > /proc/sys/net/ipv4/conf/$IFACE/mc_forwarding"
 [ -n "$IF_FORWARD_IPV6_MC" ] && ${MOCK} /bin/sh -c "echo $(yesno $IF_FORWARD_IPV6_MC) > /proc/sys/net/ipv6/conf/$IFACE/mc_forwarding"
+
+exit 0

--- a/executor-scripts/linux/forward
+++ b/executor-scripts/linux/forward
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+yesno() {
+	case "$1" in
+	yes|1)	echo 1 ;;
+	*)	echo 0 ;;
+	esac
+}
+
+[ "$PHASE" != "up" ] && exit 0
+[ -z "$VERBOSE" ] || set -x
+
+[ -n "$IF_FORWARD_IPV4" ] && ${MOCK} /bin/sh -c "echo $(yesno $IF_FORWARD_IPV4) > /proc/sys/net/ipv4/conf/$IFACE/forwarding"
+[ -n "$IF_FORWARD_IPV6" ] && ${MOCK} /bin/sh -c "echo $(yesno $IF_FORWARD_IPV6) > /proc/sys/net/ipv6/conf/$IFACE/forwarding"
+
+[ -n "$IF_FORWARD_IPV4_MC" ] && ${MOCK} /bin/sh -c "echo $(yesno $IF_FORWARD_IPV4_MC) > /proc/sys/net/ipv4/conf/$IFACE/mc_forwarding"
+[ -n "$IF_FORWARD_IPV6_MC" ] && ${MOCK} /bin/sh -c "echo $(yesno $IF_FORWARD_IPV6_MC) > /proc/sys/net/ipv6/conf/$IFACE/mc_forwarding"

--- a/tests/linux/Kyuafile
+++ b/tests/linux/Kyuafile
@@ -13,3 +13,4 @@ atf_test_program{name='gre_test'}
 atf_test_program{name='wireguard_test'}
 atf_test_program{name='ethtool_test'}
 atf_test_program{name='vxlan_test'}
+atf_test_program{name='forward_test'}

--- a/tests/linux/forward_test
+++ b/tests/linux/forward_test
@@ -1,0 +1,90 @@
+#!/usr/bin/env atf-sh
+
+. $(atf_get_srcdir)/../test_env.sh
+EXECUTOR="$(atf_get_srcdir)/../../executor-scripts/linux/forward"
+
+tests_init \
+	up_forward_v4 \
+	up_forward_v6 \
+	up_forward_v4_mc \
+	up_forward_v6_mc
+
+up_forward_v4_body() {
+	export IF_FORWARD_IPV4= IF_FORWARD_IPV6= IF_FORWARD_IPV4_MC= IF_FORWARD_IPV6_MC=
+
+	export IFACE=eth0 PHASE=up MOCK=echo IF_FORWARD_IPV4=1
+	atf_check -s exit:0 -o match:'echo 1 > /proc/sys/net/ipv4/conf/eth0/forwarding' \
+		${EXECUTOR}
+
+	export IFACE=eth0 PHASE=up MOCK=echo IF_FORWARD_IPV4=yes
+	atf_check -s exit:0 -o match:'echo 1 > /proc/sys/net/ipv4/conf/eth0/forwarding' \
+		${EXECUTOR}
+
+	export IFACE=eth0 PHASE=up MOCK=echo IF_FORWARD_IPV4=0
+	atf_check -s exit:0 -o match:'echo 0 > /proc/sys/net/ipv4/conf/eth0/forwarding' \
+		${EXECUTOR}
+
+	export IFACE=eth0 PHASE=up MOCK=echo IF_FORWARD_IPV4=no
+	atf_check -s exit:0 -o match:'echo 0 > /proc/sys/net/ipv4/conf/eth0/forwarding' \
+		${EXECUTOR}
+}
+
+up_forward_v6_body() {
+	export IF_FORWARD_IPV4= IF_FORWARD_IPV6= IF_FORWARD_IPV4_MC= IF_FORWARD_IPV6_MC=
+
+	export IFACE=eth0 PHASE=up MOCK=echo IF_FORWARD_IPV6=1
+	atf_check -s exit:0 -o match:'echo 1 > /proc/sys/net/ipv6/conf/eth0/forwarding' \
+		${EXECUTOR}
+
+	export IFACE=eth0 PHASE=up MOCK=echo IF_FORWARD_IPV6=yes
+	atf_check -s exit:0 -o match:'echo 1 > /proc/sys/net/ipv6/conf/eth0/forwarding' \
+		${EXECUTOR}
+
+	export IFACE=eth0 PHASE=up MOCK=echo IF_FORWARD_IPV6=0
+	atf_check -s exit:0 -o match:'echo 0 > /proc/sys/net/ipv6/conf/eth0/forwarding' \
+		${EXECUTOR}
+
+	export IFACE=eth0 PHASE=up MOCK=echo IF_FORWARD_IPV6=no
+	atf_check -s exit:0 -o match:'echo 0 > /proc/sys/net/ipv6/conf/eth0/forwarding' \
+		${EXECUTOR}
+}
+
+up_forward_v4_mc_body() {
+	export IF_FORWARD_IPV4= IF_FORWARD_IPV6= IF_FORWARD_IPV4_MC= IF_FORWARD_IPV6_MC=
+
+	export IFACE=eth0 PHASE=up MOCK=echo IF_FORWARD_IPV4_MC=1
+	atf_check -s exit:0 -o match:'echo 1 > /proc/sys/net/ipv4/conf/eth0/mc_forwarding' \
+		${EXECUTOR}
+
+	export IFACE=eth0 PHASE=up MOCK=echo IF_FORWARD_IPV4_MC=yes
+	atf_check -s exit:0 -o match:'echo 1 > /proc/sys/net/ipv4/conf/eth0/mc_forwarding' \
+		${EXECUTOR}
+
+	export IFACE=eth0 PHASE=up MOCK=echo IF_FORWARD_IPV4_MC=0
+	atf_check -s exit:0 -o match:'echo 0 > /proc/sys/net/ipv4/conf/eth0/mc_forwarding' \
+		${EXECUTOR}
+
+	export IFACE=eth0 PHASE=up MOCK=echo IF_FORWARD_IPV4_MC=no
+	atf_check -s exit:0 -o match:'echo 0 > /proc/sys/net/ipv4/conf/eth0/mc_forwarding' \
+		${EXECUTOR}
+}
+
+up_forward_v6_mc_body() {
+	export IF_FORWARD_IPV4= IF_FORWARD_IPV6= IF_FORWARD_IPV4_MC= IF_FORWARD_IPV6_MC=
+
+	export IFACE=eth0 PHASE=up MOCK=echo IF_FORWARD_IPV6_MC=1
+	atf_check -s exit:0 -o match:'echo 1 > /proc/sys/net/ipv6/conf/eth0/mc_forwarding' \
+		${EXECUTOR}
+
+	export IFACE=eth0 PHASE=up MOCK=echo IF_FORWARD_IPV6_MC=yes
+	atf_check -s exit:0 -o match:'echo 1 > /proc/sys/net/ipv6/conf/eth0/mc_forwarding' \
+		${EXECUTOR}
+
+	export IFACE=eth0 PHASE=up MOCK=echo IF_FORWARD_IPV6_MC=0
+	atf_check -s exit:0 -o match:'echo 0 > /proc/sys/net/ipv6/conf/eth0/mc_forwarding' \
+		${EXECUTOR}
+
+	export IFACE=eth0 PHASE=up MOCK=echo IF_FORWARD_IPV6_MC=no
+	atf_check -s exit:0 -o match:'echo 0 > /proc/sys/net/ipv6/conf/eth0/mc_forwarding' \
+		${EXECUTOR}
+}


### PR DESCRIPTION
The forward executor allows the forwarding sysctls to be modified on a per-interface basis.

Closes #136.