### PR TITLE
Bugfixes 

### DIFF
--- a/cmd/ifupdown.c
+++ b/cmd/ifupdown.c
@@ -46,7 +46,7 @@ acquire_state_lock(const char *state_path, const char *lifname)
 
 	snprintf(lockpath, sizeof lockpath, "%s.%s.lock", state_path, lifname);
 
-	int fd = open(lockpath, O_CREAT | O_WRONLY | O_TRUNC);
+	int fd = open(lockpath, O_CREAT | O_WRONLY | O_TRUNC,0600);
 	if (fd < 0)
 	{
 		if (exec_opts.verbose)

--- a/libifupdown/lifecycle.c
+++ b/libifupdown/lifecycle.c
@@ -122,12 +122,19 @@ append_to_buffer(char **buffer, size_t *buffer_len, char **end, const char *valu
 	/* Make sure there is enough room to add the value to the buffer */
 	if (*buffer_len < strlen (*buffer) + value_len + 2)
 	{
-		*buffer = realloc (*buffer, *buffer_len * 2);
-		if (*buffer == NULL)
-			/* XXX Here be dragons */
+		size_t end_offset = *end - *buffer;
+		char * tmp = realloc (*buffer, *buffer_len * 2);
+		if (tmp != NULL)
+		{
+			*buffer = tmp;
+			*end = tmp + end_offset;
+			*buffer_len = *buffer_len * 2;
+		}
+		else
+		{
 			return false;
+		}
 
-		*buffer_len = *buffer_len * 2;
 	}
 
 	/* Append value to buffer */


### PR DESCRIPTION
This patch contains 2 bugfixes in separate commits:

The POSIX specification states the folllowing about O_CREAT:
O_CREAT Create file if it does not exist. An additional argument of type mode_t must be supplied to the call.
Added for now 0600 as mode_t.

Realloc is allowed to also move the buffer and therefor the end will point to a freeed bit of memory and therefor triggering a use_after_free. For now always update the end pointer, but if needed tmp could also be compared to buffer to see if it was rellocated and only then update *end. 