### PR TITLE
static: use ip addr|route flush instead of manually deleting matching routes

### DIFF
--- a/executor-scripts/linux/static
+++ b/executor-scripts/linux/static
@@ -26,24 +26,22 @@ configure_addresses() {
 			PEER=""
 		fi
 
-		if [ -z "${MOCK}" -a "${1}" = "del" ]; then
-			# When having multiple addresses set from the same prefix they might/will(?) be configured
-			# as 'secondary' and implicitly removed when removing the non-secondary address. This
-			# leads ip complaining about not being able to remove the secondaries as they are already
-			# gone. So we ignore errors while deconfiguring addresses as they liked occur when removing
-			# a vanish address anyway.
-			${MOCK} ip "${addrfam}" addr "${1}" "${addr}" ${PEER} dev "${IFACE}" 2>/dev/null
-		else
-			${MOCK} ip "${addrfam}" addr "${1}" "${addr}" ${PEER} dev "${IFACE}"
-		fi
+		${MOCK} ip "${addrfam}" addr add "${addr}" ${PEER} dev "${IFACE}"
 	done
 }
 
 configure_gateways() {
 	for gw in ${IF_GATEWAYS}; do
 		addrfam=$(addr_family ${gw})
-		${MOCK} ip "${addrfam}" route "${1}" default via "${gw}" ${VRF_TABLE} ${METRIC} dev "${IFACE}"
+		${MOCK} ip "${addrfam}" route add default via "${gw}" ${VRF_TABLE} ${METRIC} dev "${IFACE}"
 	done
+}
+
+flush() {
+	cmd="addr"
+	arg="dev ${IFACE}"
+
+	${MOCK} ip ${cmd} flush ${arg}
 }
 
 case "$PHASE" in
@@ -52,8 +50,7 @@ up)
 	configure_gateways add
 	;;
 down)
-	configure_gateways del
-	configure_addresses del
+	flush
 	;;
 *)	exit 0 ;;
 esac

--- a/tests/linux/static_test
+++ b/tests/linux/static_test
@@ -8,9 +8,7 @@ tests_init \
 	up_ptp \
 	down \
 	vrf_up \
-	vrf_down \
-	metric_up \
-	metric_down
+	metric_up
 
 up_body() {
 	export IFACE=eth0 PHASE=up MOCK=echo IF_ADDRESSES="203.0.113.2/24 2001:db8:1000:2::2/64" \
@@ -38,10 +36,7 @@ down_body() {
 	export IFACE=eth0 PHASE=down MOCK=echo IF_ADDRESSES="203.0.113.2/24 2001:db8:1000:2::2/64" \
 		IF_GATEWAYS="203.0.113.1 2001:db8:1000:2::1"
 	atf_check -s exit:0 \
-		-o match:'addr del 203.0.113.2/24 dev eth0' \
-		-o match:'addr del 2001:db8:1000:2::2/64 dev eth0' \
-		-o match:'route del default via 203.0.113.1 metric 1 dev eth0' \
-		-o match:'route del default via 2001:db8:1000:2::1 metric 1 dev eth0' \
+		-o match:'addr flush dev eth0' \
 		${EXECUTOR}
 }
 
@@ -52,23 +47,9 @@ vrf_up_body() {
 		${EXECUTOR}
 }
 
-vrf_down_body() {
-	export IFACE=vrf-red PHASE=down MOCK=echo IF_GATEWAYS=203.0.113.2 IF_VRF_TABLE=1
-	atf_check -s exit:0 \
-		-o match:'route del default via 203.0.113.2 table 1' \
-		${EXECUTOR}
-}
-
 metric_up_body() {
 	export IFACE=vrf-red PHASE=up MOCK=echo IF_GATEWAYS=203.0.113.2 IF_VRF_TABLE=1 IF_METRIC=20
 	atf_check -s exit:0 \
 		-o match:'route add default via 203.0.113.2 table 1 metric 20' \
-		${EXECUTOR}
-}
-
-metric_down_body() {
-	export IFACE=vrf-red PHASE=down MOCK=echo IF_GATEWAYS=203.0.113.2 IF_VRF_TABLE=1 IF_METRIC=20
-	atf_check -s exit:0 \
-		-o match:'route del default via 203.0.113.2 table 1 metric 20' \
 		${EXECUTOR}
 }


### PR DESCRIPTION
This ensures we wind up with a clean slate for the interface or VRF when taking
interfaces/VRFs down.

Closes #149.