### PR TITLE
Brush up tunnels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,6 +167,7 @@ MANPAGES_5 = \
 	doc/interfaces-bridge.5 \
 	doc/interfaces-forward.5 \
 	doc/interfaces-ppp.5 \
+	doc/interfaces-tunnel.5 \
 	doc/interfaces-vrf.5 \
 	doc/interfaces-vxlan.5 \
 	doc/interfaces-wifi.5 \

--- a/doc/interfaces-tunnel.scd
+++ b/doc/interfaces-tunnel.scd
@@ -1,0 +1,161 @@
+interfaces-tunnel(5)
+
+# NAME
+
+*interfaces-tunnel* - Tunnel extensions for the interfaces(5) file format
+
+# DESCRIPTION
+
+The following options set up tunneling interfaces with ifupdown-ng.
+
+# TUNNEL-RELATED OPTIONS
+
+A tunnel interface must have a mode, remote IP and a local IP or device
+set, all other options are optional.
+
+*tunnel-mode* _mode_
+	Denotes the mode for this tunnel. Basically all tunnel modes supported
+	by Linux / iproute2 are supported as well.  This includes but is not
+	limited to _gre_/_gretap_, _ip6gre_/_ip6gretap_, _ipip_/_ip6ip_/_sit_.
+
+*tunnel-local* _IP_
+	Denotes the IP address used as the local tunnel endpoint.  According
+	to the _tunnel-mode_ an IPv4 or IPv6 address has to be given.
+	For compatiblity to ifupdown1 _local_ is an alias for this option.
+
+*tunnel-local-dev* _interface_
+	When the local IP address the tunnel should be established from isn't
+	static and therefore might change (e.g. configured by DHCP or PPP) it
+	might be desireable to just use the address configured on _interface_.
+	When _tunnel-local-dev_ is given instead of _tunnel-local_ ifupdown-ng
+	will try to determine the IP address set on the given _interface_ with
+	respect to the address family required to set up a tunnel of the given
+	_mode_ and use this to set up the tunnel.
+
+*tunnel-remote* _IP_
+	Denotes the IP address used as the remote tunnel endpoint.  According
+	to the _tunnel-mode_ an IPv4 or IPv6 address has to be given.
+	For compatiblity to ifupdown1 _endpoint_ is an alias for this option.
+
+*tunnel-physdev* _interface_
+	Denotes the _interface_ the encapsulated packets should be sent out by.
+	This comes in handy when using VRFs to denote that the local tunnel
+	endpoint should be terminated in VRF _interface_ or the VRF associated
+	with _interface_.
+
+	Note: Depending on the _mode_ of the tunnel either the VRF interface
+	or the real underlay interface may have to given as _interface_.
+
+*tunnel-ttl* _ttl_
+	Denotes the TTL value to use in outgoing packets.  _ttl_ is a number in the
+	range 1 - 255 whereas 0 is a special value meaning that packets inherit the
+	TTL value.  The default for IPv4 tunnels is to inherit the TTL, for IPv6
+	tunnels it's 64.  For compatiblity to ifupdown1 _ttl_ is an alias for this option.
+
+
+
+# IPIP/SIT-RELATED OPTIONS
+
+*tunnel-encap* _encap_
+	Denotes the type of secondary UDP encapsulation to use for this tunnel
+	if any.  Supported _encap_ values are _fou_, _gue_, and _none_.
+	_fou_ indicates Foo-Over-UDP, _gue_ indicates Generic UDP Encapsulation.
+
+# GRE-RELATED OPTIONS
+
+*tunnel-encap* _encap_
+	Denotes the type of secondary UDP encapsulation to use for this tunnel
+	if any.  Supported _encap_ values are _fou_, _gue_, and _none_.
+	_fou_ indicates Foo-Over-UDP, _gue_ indicates Generic UDP Encapsulation.
+
+*tunnel-key* _key_
+	Denotes the_key to used for keyed GRE to allow multiple tunnels between
+	the same two endpoints.  _key_ is either a number or an IPv4 address-
+	like dotted quad.  The key parameter specifies the same key to use in both
+	directions.  The _tunnel-ikey_ and _tunnel-okey_ parameters specify different
+	keys for input and output.  For compatiblity to ifupdown1 _key_ is an alias
+	for this option.
+
+*tunnel-hoplimit* _ttl_
+	Denotes the Hop Limit value to use in outgoing packets for _ip6gre_/_ip6gretap_
+	tunnels.
+
+*tunnel-ignore-df* _bool_
+	Denotes wether to enable/disable IPv4 DF suppression on this tunnel.  Normally
+	datagrams that exceed the MTU will be fragmented; the presence of the DF flag
+	inhibits this, resulting instead in an ICMP Unreachable (Fragmentation Required)
+	message.  Enabling this attribute causes the DF flag to be ignored.
+
+*tunnel-ikey* _key_
+	Denotes the key to used for keyed GRE for packets received.  See _tunnel-key_
+	for details.
+
+*tunnel-okey* _key_
+	Denotes the key to used for keyed GRE for packets sent out.  See _tunnel-key_
+	for details.
+
+*tunnel-pmtudisc* _bool_
+	Denotes wether to enable/disable Path MTU Discovery on this tunnel.  It is
+	enabled by default.  Note that a fixed ttl is incompatible with this option:
+	tunneling with a fixed ttl always makes pmtu discovery.
+
+*tunnel-tos* _tos_
+	Denotes the TOS value to use in outgoing packets.
+
+
+# EXAMPLES
+
+A simple GRE tunnel
+
+```
+auto gre0
+iface gre0
+	tunnel-mode gre
+	tunnel-remote 198.51.100.1
+	tunnel-local 203.0.113.2
+	#
+	address 192.0.2.42/24
+	address 2001:db8::42/64
+```
+
+A GRE tunnel where the local IP is learned from _eth0_
+
+```
+auto gre1
+iface gre1
+	tunnel-mode gre
+	tunnel-remote 198.51.100.1
+	tunnel-local-dev eth0
+	#
+	address 192.0.2.42/24
+	address 2001:db8::42/64
+```
+
+A GRE tunnel which transfers encapasulated packets via _eth0_ which is part
+of a VRF.
+
+```
+auto eth0
+iface eth0
+	address 203.0.113.2/24
+	gateway 203.0.113.1
+	vrf vrf_external
+
+auto tun-vrf
+iface tun-vrf
+	tunnel-mode gre
+	tunnel-remote 198.51.100.1
+	tunnel-local 203.0.113.2
+	tunnel-physdev eth0
+	#
+	address 192.0.2.42/24
+	address 2001:db8::42/64
+
+auto vrf_external
+iface vrf_external
+	vrf-table 1023
+```
+
+# AUTHORS
+
+Maximilian Wilhelm <max@sdn.clinic>

--- a/doc/interfaces.scd
+++ b/doc/interfaces.scd
@@ -178,7 +178,8 @@ most common executors are:
 
 *tunnel*
 	The interface is a tunnel.  Configuration of tunnels
-	requires the *tunnel* package to be installed.
+	requires the *tunnel* package to be installed on Alpine
+	Linux.
 
 *vrf*
 	The interface is a VRF.  Configuration of VRFs requires
@@ -249,6 +250,7 @@ iface eth0
 *interfaces-forward*(5)
 *interfaces-mpls*(5)
 *interfaces-ppp*(5)
+*interfaces-tunnel*(5)
 *interfaces-vrf*(5)
 *interfaces-vxlan*(5)
 *interfaces-wifi*(5)

--- a/executor-scripts/linux/tunnel
+++ b/executor-scripts/linux/tunnel
@@ -2,13 +2,20 @@
 # Based on alpine's tunnel configuration script.
 # Copyright (c) 2017 Kaarle Ritvanen
 # Copyright (c) 2020 Ariadne Conill (extended for ifupdown-ng)
-# Copyright (c) 2021 Maximilian Wilhelm (make sure mode/type is 1st parameter)
+# Copyright (c) 2021 Maximilian Wilhelm (make sure mode/type is 1st parameter, add more options)
 
 [ -z "$IF_TUNNEL_LOCAL" -a -z "$IF_TUNNEL_LOCAL_DEV" ] && exit 1
 [ -z "$IF_TUNNEL_REMOTE" ] && exit 1
 [ -z "$IF_TUNNEL_MODE" ] && exit 1
 
 [ -n "$VERBOSE" ] && set -x
+
+yesno() {
+        case "$1" in
+        yes|1)  echo 1 ;;
+        *)      echo 0 ;;
+        esac
+}
 
 # Figure out address familiy
 FAMILY="4"
@@ -70,6 +77,29 @@ if [ ${PHASE} = "create" -a ! "${IF_TUNNEL_LOCAL}" -a "${IF_TUNNEL_LOCAL_DEV}" ]
 fi
 
 
+# Handle boolean switches
+MORE_PARAMS=""
+if [ "${IF_TUNNEL_IGNORE_DF}" ]; then
+	if $(yesno "${IF_TUNNEL_IGNORE_DF}"); then
+		MORE_PARAMS="ignore-df"
+	else
+		MORE_PARAMS="noignore-df"
+	fi
+
+	unset IF_TUNNEL_IGNORE_DF
+fi
+
+if [ "${IF_TUNNEL_PMTUDISC}" ]; then
+	if $(yesno "${IF_TUNNEL_PMTUDISC}"); then
+		MORE_PARAMS="pmtudisc"
+	else
+		MORE_PARAMS="nopmtudisc"
+	fi
+
+	unset IF_TUNNEL_PMTUDISC
+fi
+
+
 # Mangle residual IF_TUNNEL_* params into single string
 PARAMS=$(set | sed -E '
 	s/^IF_TUNNEL_([A-Z0-9_]+)=(.+)/\1\n\2/
@@ -87,7 +117,7 @@ PARAMS=$(set | sed -E '
 
 case "$PHASE" in
 create)
-	${MOCK} eval ip -$FAMILY $OBJECT add $IFACE $TYPE_KW $TUNNEL_MODE $PARAMS
+	${MOCK} eval ip -$FAMILY $OBJECT add $IFACE $TYPE_KW $TUNNEL_MODE $PARAMS $MORE_PARAMS
 	;;
 destroy)
 	${MOCK} ip -$FAMILY $OBJECT del $IFACE

--- a/executor-scripts/linux/tunnel
+++ b/executor-scripts/linux/tunnel
@@ -4,18 +4,18 @@
 # Copyright (c) 2020 Ariadne Conill (extended for ifupdown-ng)
 # Copyright (c) 2021 Maximilian Wilhelm (make sure mode/type is 1st parameter)
 
-[ -z "$IF_TUNNEL_LOCAL" ] && exit 1
+[ -z "$IF_TUNNEL_LOCAL" -a -z "$IF_TUNNEL_LOCAL_DEV" ] && exit 1
 [ -z "$IF_TUNNEL_REMOTE" ] && exit 1
 [ -z "$IF_TUNNEL_MODE" ] && exit 1
 
 [ -n "$VERBOSE" ] && set -x
 
 # Figure out address familiy
-FAMILY="-4"
+FAMILY="4"
 
 case "$IF_TUNNEL_MODE" in
 vti6|ipip6|ip6*)
-	FAMILY="-6"
+	FAMILY="6"
 	;;
 esac
 
@@ -41,6 +41,35 @@ case "${IF_TUNNEL_MODE}" in
 esac
 
 
+# If 'tunnel-local <IP>' was not given but 'tunnel-local-dev <iface>' is given try
+# to figure out the IP of the underlay device (wrt the address family used for this
+# tunnel) and use this to set up the tunnel
+if [ ${PHASE} = "create" -a ! "${IF_TUNNEL_LOCAL}" -a "${IF_TUNNEL_LOCAL_DEV}" ]; then
+	if [ "${FAMILY}" = "4" ]; then
+		ip=$(ip -4 -brief addr show dev "${IF_TUNNEL_LOCAL_DEV}" 2>/dev/null | awk '{ print $3 }' | cut -d/ -f1)
+
+	# For IPv6 we try to use a non-temporary address (-> privacy extensions)
+	else
+		# Get all IPv6 addres configured on $IF_TUNNEL_LOCAL_DEV which are not
+		# temporary (due to privacy extensions). We do not filter for "mgmtaddr"
+		# "scope global" etc. as we don't want to make further assumptions on
+		# whether a user wants to use a link local address configured to this interface.
+		#
+		# The assumption that a temporary address configured by PE isn't suited
+		# to terminate a tunnel should hold in nearly all setups, I hope.
+		ip=$(ip -6 addr show dev "${IF_TUNNEL_LOCAL_DEV}" -temporary | grep inet6 | head -n1 | awk '{ print $2 }' | cut -d/ -f1)
+	fi
+
+	if [ ! "${ip}" ]; then
+		echo "Unable to determine the IPv${FAMILIY} address of tunnel-local-dev ${IF_TUNNEL_LOCAL_DEV}!"
+		exit 1
+	fi
+
+	unset IF_TUNNEL_LOCAL_DEV
+	export IF_TUNNEL_LOCAL="${ip}"
+fi
+
+
 # Mangle residual IF_TUNNEL_* params into single string
 PARAMS=$(set | sed -E '
 	s/^IF_TUNNEL_([A-Z0-9_]+)=(.+)/\1\n\2/
@@ -58,12 +87,12 @@ PARAMS=$(set | sed -E '
 
 case "$PHASE" in
 create)
-	${MOCK} eval ip $FAMILY $OBJECT add $IFACE $TYPE_KW $TUNNEL_MODE $PARAMS
+	${MOCK} eval ip -$FAMILY $OBJECT add $IFACE $TYPE_KW $TUNNEL_MODE $PARAMS
 	;;
 destroy)
-	${MOCK} ip $FAMILY $OBJECT del $IFACE
+	${MOCK} ip -$FAMILY $OBJECT del $IFACE
 	;;
 depend)
-	echo "$IF_TUNNEL_DEV"
+	echo "${IF_TUNNEL_DEV}" "${IF_TUNNEL_LOCAL_DEV}"
 	;;
 esac


### PR DESCRIPTION
- Add support for `tunnel-local-dev` to automatically determine the IP of the local tunnel endpoint
- Add `interfaces-tunnel` man page
- Add support for setting `[no]ignore-df` as well as  `[no]pmtudisc` options for tunnels

This could need another round of tests before this is merged. Kyua tests don't help much here as this relies on configured IP addresses and what `iproute2` allows to configured.