### PR TITLE
vxlan: Add support for PTMP setups and rename options to vxlan-peer-{ips,group}

### DIFF
--- a/doc/interfaces-vxlan.scd
+++ b/doc/interfaces-vxlan.scd
@@ -32,7 +32,8 @@ other options are optional.
 
 *vxlan-physdev* _interface_
 	Specifies the physical ("underlay") device to use for tunnel
-	endpoint communication.
+	endpoint communication.  This is required for setups using
+	multicast.
 
 *vxlan-local-ip* _address_
 	Specifies the source IP address to use in outgoing packets.
@@ -53,11 +54,11 @@ other options are optional.
 	is an alias for this option, too.
 
 *vxlan-peer-group* _multicast group_
-	Specifies the multicast group IP address to join. This parameter
-	cannot be specified with the _vxlan-peer-ip_ parameter.
-	For compatibility with ifupdown2 _vxlan-svcnodeip_ is an alias for
-	this option and for compatibility with previos version of ifupdown-ng
-	_vxlan-remote-group_ is an alias, too.
+	Specifies the multicast group address to join, requires _vxlan-phsydev_
+	to be set as well.  This parameter cannot be specified in combination
+	with the _vxlan-peer-ips_ parameter.  For compatibility with ifupdown2
+	_vxlan-svcnodeip_ is an alias for this option and for compatibility
+	with previos version of ifupdown-ng _vxlan-remote-group_ is an alias, too.
 
 *vxlan-learning* _on/off_
 	Specifies if unknown source link layer addresses and IP addresses

--- a/doc/interfaces-vxlan.scd
+++ b/doc/interfaces-vxlan.scd
@@ -39,19 +39,25 @@ other options are optional.
 	For compatiblity with ifupdown2 _vxlan-local-tunnelip_ is an
 	alias for this parameter.
 
-*vxlan-remote-ip* _address_
-	Specifies the unicast destination IP address to use in outgoing
+*vxlan-peer-ips* _list of IP addresses_
+	Specifies the unicast destination IP address(es) to use in outgoing
 	packets when the destination link layer address is not known in
-	the VXLAN device forwarding database. This parameter cannot be
-	specified with the _vxlan-remote-group_ parameter.
-	For compatiblity with ifupdown2 _vxlan-remoteip_ is an alias for
-	this parameter.
+	the VXLAN device forwarding database.  This option can be used to
+	form Point-to-Point as well as Point-to-Multipoint VXLAN tunnels/
+	overlays depending on how many peer IPs are given.  If more than one
+	IP address is given a Point-to-Multipoint overlay is being set up
+	and ingress / head-end replication will be used by the Linux Kernel.
+	This option cannot be used together with _vxlan-peer-group_ option.
+	For compatiblity with ifupdown2 _vxlan-remoteip_ is an alias for this option
+	and for compatibility with previos versions of ifupdown-ng _vxlan-remote-ip_
+	is an alias for this option, too.
 
-*vxlan-remote-group* _multicast group_
+*vxlan-peer-group* _multicast group_
 	Specifies the multicast group IP address to join. This parameter
-	cannot be specified with the _vxlan-remote-ip_ parameter.
+	cannot be specified with the _vxlan-peer-ip_ parameter.
 	For compatibility with ifupdown2 _vxlan-svcnodeip_ is an alias for
-	this parameter.
+	this option and for compatibility with previos version of ifupdown-ng
+	_vxlan-remote-group_ is an alias, too.
 
 *vxlan-learning* _on/off_
 	Specifies if unknown source link layer addresses and IP addresses
@@ -79,20 +85,44 @@ iface vx_v1001_padcty
 	mtu 1560
 ```
 
+The same works just fine with IPv6 in the underlay:
+
+```
+auto vx_v1400_padcty
+iface vx_v1400_padcty
+        vxlan-id           917505
+        vxlan-physdev      vlan1400
+        vxlan-peer-group   ff42:1400::1
+        #
+        hwaddress f2:00:0d:01:14:00
+        mtu 1560
+```
+
 Note that the underlay must have an MTU of at least 1610 to
-carry the encapsulated packets.
+carry the encapsulated packets of the two VTEPs above.
 
 
-A VTEP with one peer (point-to-point configuration):
+A VTEP with one peer (unicast point-to-point configuration):
 
 ```
 auto vx_ptp1
 iface vx_ptp1
 	vxlan-id        2342
 	vxlan-local-ip  192.0.2.42
-	vxlan-remote-ip 198.51.100.23
+	vxlan-peer-ips  198.51.100.23
 	#
 	hwaddress f2:00:c1:01:10:01
+```
+
+
+A VTEP with multiple peers (unicast point-to-multipoint with ingress / head-end replication):
+
+```
+auto vx_her
+iface vx_her
+	vxlan-id	1337
+	vxlan-local-ip	2001:db8:1::1
+	vxlan-peer-ips  2001:db8:2::23 2001:db8:3::42 2001:db8:4::84
 ```
 
 # AUTHORS

--- a/executor-scripts/linux/vxlan
+++ b/executor-scripts/linux/vxlan
@@ -10,8 +10,8 @@
 # IF_VXLAN_ID		The VXLAN Network Identifier (VNI)
 # IF_VXLAN_PHYSDEV	Specifies the physical device to use for tunnel endpoint communication
 # IF_VXLAN_LOCAL_IP	Specifies the source IP address to use in outgoing packets
-# IF_VXLAN_REMOTE_IP	IP of the remote VTEP endpoint (for ptp mode)
-# IF_VXLAN_REMOTE_GROUP	Multicast group to use for this VNI (for ptmp mode)
+# IF_VXLAN_PEER_IPS	Space separated list of IPs of the remote VTEP endpoint (for ptp/ptmp mode with ingress replication)
+# IF_VXLAN_PEER_GROUP	Multicast group to use for this VNI (for ptmp mode with multicast)
 # IF_VXLAN_LEARNING	Wether to activate MAC learning on this instance (on/off)
 # IF_VXLAN_AGEING	Specifies the lifetime in seconds of FDB entries learnt by the kernel
 # IF_VXLAN_DSTPORT	UDP destination port to communicate to the remote VXLAN tunnel endpoint (default 4789)
@@ -36,17 +36,27 @@ case "$PHASE" in
 		fi
 
 		# Input validation
-		if [ "${IF_VXLAN_REMOTE_IP}" -a "${IF_VXLAN_REMOTE_GROUP}" ]; then
-			echo "Error on ${IFACE} (vxlan): Only one of 'remote' and 'group' can be given!" >&2
+		if [ "${IF_VXLAN_PEER_IPS}" -a "${IF_VXLAN_PEER_GROUP}" ]; then
+			echo "Error on ${IFACE} (vxlan): Only one of 'vxlan-peer-ips' and 'vxlan-peer-group' can be used!" >&2
 			exit 1
+		fi
+
+		# Check if we should operate in unicast ptp or ptmp mode
+		if [ "${IF_VXLAN_PEER_IPS}" ]; then
+			# If it's only one thing which looks like an IPv4/IPv6 address we assume it's ptp
+			if echo "${IF_VXLAN_PEER_IPS}" | grep -q '^[[:space:]]*[[:xdigit:].:]\+[[:space:]]*$'; then
+				UCAST_MODE="ptp"
+			else
+				UCAST_MODE="ptmp"
+			fi
 		fi
 
 		# Gather arguments
 		ARGS=""
 		[ "${IF_VXLAN_PHYSDEV}" ] && ARGS="${ARGS} dev ${IF_VXLAN_PHYSDEV}"
 		[ "${IF_VXLAN_LOCAL_IP}" ] && ARGS="${ARGS} local ${IF_VXLAN_LOCAL_IP}"
-		[ "${IF_VXLAN_REMOTE_IP}" ] && ARGS="${ARGS} remote ${IF_VXLAN_REMOTE_IP}"
-		[ "${IF_VXLAN_REMOTE_GROUP}" ] && ARGS="${ARGS} group ${IF_VXLAN_REMOTE_GROUP}"
+		[ "${UCAST_MODE}" = "ptp" ] && ARGS="${ARGS} remote ${IF_VXLAN_PEER_IPS}"
+		[ "${IF_VXLAN_PEER_GROUP}" ] && ARGS="${ARGS} group ${IF_VXLAN_PEER_GROUP}"
 		[ "${IF_VXLAN_AGEING}" ] && ARGS="${ARGS} ageing ${IF_VXLAN_AGEING}"
 
 		# Linux uses non-standard default port - WTF?
@@ -67,6 +77,13 @@ case "$PHASE" in
 		esac
 
 		${MOCK} ip link add "${IFACE}" type vxlan id "${IF_VXLAN_ID}" ${ARGS}
+
+		# Set up FDB entries for peer VTEPs
+		if [ "${UCAST_MODE}" = "ptmp" ]; then
+			for peer in ${IF_VXLAN_PEER_IPS}; do
+				${MOCK} bridge fdb append 00:00:00:00:00:00 dev "${IFACE}" dst "${peer}" self permanent
+			done
+		fi
 		;;
 
 	destroy)

--- a/libifupdown/interface-file.c
+++ b/libifupdown/interface-file.c
@@ -100,8 +100,10 @@ static const struct remap_token tokens[] = {
 	{"vendor", "dhcp-vendor"},			/* legacy ifupdown */
 	{"vrf", "vrf-member"},				/* ifupdown2 */
 	{"vxlan-local-tunnelip", "vxlan-local-ip"},	/* ifupdown2 */
-	{"vxlan-remoteip", "vxlan-remote-ip"},		/* ifupdown2 */
-	{"vxlan-svcnodeip", "vxlan-remote-group"},	/* ifupdown2 */
+	{"vxlan-remote-group", "vxlan-peer-group"},	/* ifupdown-ng */
+	{"vxlan-remoteip", "vxlan-peer-ips"},		/* ifupdown2 */
+	{"vxlan-remote-ip", "vxlan-peer-ips"},		/* ifupdown-ng */
+	{"vxlan-svcnodeip", "vxlan-peer-group"},	/* ifupdown2 */
 };
 
 static int

--- a/tests/linux/vxlan_test
+++ b/tests/linux/vxlan_test
@@ -5,7 +5,8 @@ EXECUTOR="$(atf_get_srcdir)/../../executor-scripts/linux/vxlan"
 
 tests_init \
 	create_simple \
-	create_ucast \
+	create_ucast_ptp \
+	create_ucast_ptmp \
 	create_mcast \
 	create_physdev \
 	create_dstport \
@@ -18,14 +19,24 @@ create_simple_body() {
 		${EXECUTOR}
 }
 
-create_ucast_body() {
-	export IFACE=vx_foo PHASE=create MOCK=echo IF_VXLAN_ID=2342 IF_VXLAN_REMOTE_IP=192.2.0.42
+create_ucast_ptp_body() {
+	export IFACE=vx_foo PHASE=create MOCK=echo IF_VXLAN_ID=2342 IF_VXLAN_PEER_IPS=192.2.0.42
 	atf_check -s exit:0 -o match:'ip link add vx_foo type vxlan id 2342 remote 192.2.0.42' \
 		${EXECUTOR}
 }
 
+create_ucast_ptmp_body() {
+	export IFACE=vx_foo PHASE=create MOCK=echo IF_VXLAN_ID=2342 IF_VXLAN_PEER_IPS="10.0.0.1 10.0.0.2 10.0.0.3"
+	atf_check -s exit:0 \
+		-o match:'ip link add vx_foo type vxlan id 2342 dstport 4789' \
+		-o match:'bridge fdb append 00:00:00:00:00:00 dev vx_foo dst 10.0.0.1 self permanent' \
+		-o match:'bridge fdb append 00:00:00:00:00:00 dev vx_foo dst 10.0.0.2 self permanent' \
+		-o match:'bridge fdb append 00:00:00:00:00:00 dev vx_foo dst 10.0.0.3 self permanent' \
+		${EXECUTOR}
+}
+
 create_mcast_body() {
-	export IFACE=vx_foo PHASE=create MOCK=echo IF_VXLAN_ID=2342 IF_VXLAN_REMOTE_GROUP=225.0.8.15
+	export IFACE=vx_foo PHASE=create MOCK=echo IF_VXLAN_ID=2342 IF_VXLAN_PEER_GROUP=225.0.8.15
 	atf_check -s exit:0 -o match:'ip link add vx_foo type vxlan id 2342 group 225.0.8.15' \
 		${EXECUTOR}
 }


### PR DESCRIPTION
This commit adds support for configuring static PTMP overlays with VXLAN by
  allowing to specify multiple IPs for »vxlan-peer-ips«.  If more than one IP
  is given ifupdown-ng will set up additional FDB entries for all peer IPs and
  the Linux Kernel will do ingres / head-end replication for BUM traffic.

  For a cleaner naming schema and simliar names to commercial vendor CLIs the
  options to specify unicast or multicast peers have been renamed and aliases
  added for compatibility to previous versions of ifupdown-ng:
   * »vxlan-remote-ip« now is named »vxlan-peer-ips«
   * »vxlan-remote-group« now is called »vxlan-peer-group«