### PR TITLE
Fix a bug in the wifi executor script

### DIFF
--- a/executor-scripts/linux/wifi
+++ b/executor-scripts/linux/wifi
@@ -79,7 +79,7 @@ stop_wpa_supplicant() {
 	[ -z "$IF_WIFI_CONFIG_PATH" ] && rm -- "$WIFI_CONFIG_PATH"
 
 	# If there is no PIDFILE, there is nothing we can do
-	[ ! -d "$PIDFILE" ] && return
+	[ ! -f "$PIDFILE" ] && return
 
 	pid=$(cat "$PIDFILE")
 	rm -- "$PIDFILE"


### PR DESCRIPTION
When stopping wpa_supplicant, the code is supposed to check if a file named $PIDFILE exists and kill the process listed inside. Instead it was checking if a directory named $PIDFILE exists and because this was never the case, killing of the wpa_supplicant process would always silently fail.

This would, after a few invocations of the ifup command, leave the system with large number of running wpa_supplicant processes, all trying to take control of the same interface.