### PR TITLE
Quote variables before passing to wpa_passphrase

### DIFF
--- a/executor-scripts/linux/wifi
+++ b/executor-scripts/linux/wifi
@@ -47,7 +47,7 @@ generate_config() {
 	[ -z "$IF_WIFI_PSK" ] && die "wifi-psk not set"
 
 	# We use a pipeline here to avoid leaking PSK into the process name.
-	(echo $IF_WIFI_PSK | /sbin/wpa_passphrase $IF_WIFI_SSID) >$WIFI_CONFIG_PATH
+	(echo "$IF_WIFI_PSK" | /sbin/wpa_passphrase "$IF_WIFI_SSID") >$WIFI_CONFIG_PATH
 
 	[ ! -e "$WIFI_CONFIG_PATH" ] && die "failed to write temporary config: $WIFI_CONFIG_PATH"
 }


### PR DESCRIPTION
Both PSK and SSID can contain/end with spaces.

As of now 'ifup wlan0' won't generate a valid wpa_supplicant config
file for:

  auto wlan0
  iface wlan0
      wifi-ssid two space characters
      wifi-psk psk ending with a space
      use dhcp

This patch fixes that by adding necessary quotes around corresponding
IF_WIFI environment variables.

Signed-off-by: Stanislav Kholmanskikh <stanislav.kholmanskikh@bell-sw.com>