### PR TITLE
libifupdown: check executor exit status in handle_executors_for_phase

### DIFF
--- a/libifupdown/lifecycle.c
+++ b/libifupdown/lifecycle.c
@@ -66,20 +66,25 @@ handle_single_executor_for_phase(const struct lif_dict_entry *entry, const struc
 static bool
 handle_executors_for_phase(const struct lif_execute_opts *opts, char *const envp[], const struct lif_interface *iface, bool up, const char *phase)
 {
+	bool ret = true;
 	const struct lif_node *iter;
 
 	if (up)
 	{
-		LIF_DICT_FOREACH(iter, &iface->vars)
-			handle_single_executor_for_phase(iter->data, opts, envp, phase, iface->ifname);
+		LIF_DICT_FOREACH(iter, &iface->vars) {
+			if (!handle_single_executor_for_phase(iter->data, opts, envp, phase, iface->ifname))
+				ret = false;
+		}
 	}
 	else
 	{
-		LIF_DICT_FOREACH_REVERSE(iter, &iface->vars)
-			handle_single_executor_for_phase(iter->data, opts, envp, phase, iface->ifname);
+		LIF_DICT_FOREACH_REVERSE(iter, &iface->vars) {
+			if (!handle_single_executor_for_phase(iter->data, opts, envp, phase, iface->ifname))
+				ret = false;
+		}
 	}
 
-	return true;
+	return ret;
 }
 
 static bool


### PR DESCRIPTION
Without this patch, `handle_executors_for_phase` would always return true,
even if the executor exited with a non-zero exit status. I noticed this
in conjunction with the dhcp executor were libifupdown would incorrectly
assume that the executor was executed successfully if no lease was
acquired. This caused ifupdown to get into a weird state where it
assumed that the interface was configured successfully even though it
wasn't, thus requiring an explicit `ifdown <interface>` before
it was possible to acquire a lease again with `ifup <interface>`.