### PR TITLE
wireguard: Add support for wg-quick compatible conf files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,8 @@ EXECUTOR_SCRIPTS_OPT ?= \
 	vrf \
 	vxlan \
 	wifi \
-	wireguard
+	wireguard \
+	wireguard-quick
 
 EXECUTOR_SCRIPTS ?= ${EXECUTOR_SCRIPTS_CORE} ${EXECUTOR_SCRIPTS_OPT}
 

--- a/doc/interfaces-wireguard.scd
+++ b/doc/interfaces-wireguard.scd
@@ -26,6 +26,10 @@ allow to set up Wireguard VPN tunnels.
 	manually once and then dump the configuration using *wg showconf*
 	and save this to _path_.
 
+*wireguard-quick*
+	Use this executor for rely on *wg-quick* instead and use working
+	*wg-quick* configurations.
+
 
 # EXAMPLES
 
@@ -49,6 +53,14 @@ iface wg-bar
 	#
 	address 192.0.2.23/42
 	address 2001:db8::23/64
+```
+
+A Wireguard VPN tunnel with wg-quick:
+
+```
+auto wg-bar
+iface wg-bar
+	use wireguard-quick
 ```
 
 # AUTHORS

--- a/executor-scripts/linux/wireguard-quick
+++ b/executor-scripts/linux/wireguard-quick
@@ -1,0 +1,11 @@
+#!/bin/sh
+[ -n "$VERBOSE" ] && set -x
+
+case "$PHASE" in
+create)
+	${MOCK} wg-quick up $IFACE
+	;;
+destroy)
+	${MOCK} wg-quick down $IFACE
+	;;
+esac


### PR DESCRIPTION
Hi,

As many people I set up wireguard configuration using 'wg-quick' but after trying to automatize it with ifupdown scripts I discovered that 'wg setconf' is uncompatible with 'wg-quick' options. I think that this could help for using this configuration directly with 'use wireguard-quick' instead 'use wireguard'.

