### PR TITLE
Replace use of PATH_MAX with GNU asprintf

### DIFF
--- a/cmd/ifctrstat-linux.c
+++ b/cmd/ifctrstat-linux.c
@@ -13,6 +13,7 @@
  * from the use of this software.
  */
 
+#define _GNU_SOURCE
 #include <errno.h>
 #include <limits.h>
 #include <stdio.h>
@@ -47,7 +48,7 @@ read_counter(const char *interface, const char *counter)
 {
 	FILE *fp;
 	const char *path;
-	char full_path[PATH_MAX];
+	char *full_path;
 	char buffer[1024];
 	size_t in_count;
 	struct counter_desc *ctrdata;
@@ -62,9 +63,8 @@ read_counter(const char *interface, const char *counter)
 		return NULL;
 	}
 
-	if (snprintf(full_path, PATH_MAX, "/sys/class/net/%s/statistics/%s", interface, path) > PATH_MAX)
+	if (asprintf(&full_path, "/sys/class/net/%s/statistics/%s", interface, path) < 0)
 	{
-		errno = ENOMEM;
 		return NULL;
 	}
 
@@ -73,6 +73,9 @@ read_counter(const char *interface, const char *counter)
 	{
 		return NULL;
 	}
+
+	free(full_path);
+	full_path = NULL;
 
 	in_count = fread(buffer, 1, sizeof(buffer), fp);
 


### PR DESCRIPTION
This is to fix a build failure on Debian hurd-i386, see [buildd logs](https://buildd.debian.org/status/fetch.php?pkg=ifupdown-ng&arch=hurd-i386&ver=0.11.4%7Erc1-1&stamp=1643650932&raw=0)

Apparently PATH_MAX is not mandated by POSIX but rather "may" be defined. See https://www.gnu.org/software/hurd/community/gsoc/project_ideas/maxpath.html