### PR TITLE
dhcp: ignore fails on stopping the dhcp client process

### DIFF
--- a/executor-scripts/linux/dhcp
+++ b/executor-scripts/linux/dhcp
@@ -62,6 +62,6 @@ impl=$(determine_implementation)
 
 case "$PHASE" in
 up) start $impl ;;
-down) stop $impl ;;
+down) stop $impl || true ;;
 *) ;;
 esac


### PR DESCRIPTION
This allows for successfully taking down an interface that doesn't use DHCP yet, but with `use dhcp` added in the meantime to /etc/network/interfaces