### PR TITLE
libifupdown: stop executor evaluation after an executor fails

### DIFF
--- a/cmd/ifupdown.c
+++ b/cmd/ifupdown.c
@@ -198,6 +198,7 @@ static bool
 change_auto_interfaces(struct lif_dict *collection, struct lif_dict *state, struct match_options *opts)
 {
 	struct lif_node *iter;
+	bool ret = true;
 
 	LIF_DICT_FOREACH(iter, collection)
 	{
@@ -215,11 +216,14 @@ change_auto_interfaces(struct lif_dict *collection, struct lif_dict *state, stru
 		    fnmatch(opts->include_pattern, iface->ifname, 0))
 			continue;
 
-		if (!change_interface(iface, collection, state, iface->ifname, false))
-			return false;
+		if (!change_interface(iface, collection, state, iface->ifname, false)) {
+			ret = false;
+			fprintf(stderr, "%s: failed to change state for interface %s\n", argv0, iface->ifname);
+			continue;
+		}
 	}
 
-	return true;
+	return ret;
 }
 
 static int

--- a/libifupdown/lifecycle.c
+++ b/libifupdown/lifecycle.c
@@ -72,15 +72,19 @@ handle_executors_for_phase(const struct lif_execute_opts *opts, char *const envp
 	if (up)
 	{
 		LIF_DICT_FOREACH(iter, &iface->vars) {
-			if (!handle_single_executor_for_phase(iter->data, opts, envp, phase, iface->ifname))
+			if (!handle_single_executor_for_phase(iter->data, opts, envp, phase, iface->ifname)) {
 				ret = false;
+				break;
+			}
 		}
 	}
 	else
 	{
 		LIF_DICT_FOREACH_REVERSE(iter, &iface->vars) {
-			if (!handle_single_executor_for_phase(iter->data, opts, envp, phase, iface->ifname))
+			if (!handle_single_executor_for_phase(iter->data, opts, envp, phase, iface->ifname)) {
 				ret = false;
+				break;
+			}
 		}
 	}
 


### PR DESCRIPTION
Without this commit, all executors of a given phase will be executed
even if one of them fails. This commit adjusts handle_executors_for_phase
to stop execution if a single executor for a given phase exits with a
non-zero exit status.

This is a follow-up to 6f52157335aee39b6fc25a1dfb0a86dadd6b5c5d.