### PR TITLE
Add optional link state detection support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 LAYOUT ?= linux
 SCDOC := scdoc
 LIBBSD_CFLAGS =
+LIBMNL_CFLAGS =
 LIBBSD_LIBS =
+LIBMNL_LIBS =
 
 PACKAGE_NAME := ifupdown-ng
 PACKAGE_VERSION := 0.12.1
@@ -18,6 +20,7 @@ CFLAGS ?= -ggdb3 -Os
 CFLAGS += -Wall -Wextra -Werror
 CFLAGS += -Wmissing-declarations -Wmissing-prototypes -Wcast-align -Wpointer-arith -Wreturn-type
 CFLAGS += ${LIBBSD_CFLAGS}
+CFLAGS += ${LIBMNL_CFLAGS}
 CPPFLAGS = -I.
 CPPFLAGS += -DINTERFACES_FILE=\"${INTERFACES_FILE}\"
 CPPFLAGS += -DSTATE_FILE=\"${STATE_FILE}\"
@@ -79,6 +82,16 @@ IFPARSE_SRC = cmd/ifparse.c
 MULTICALL_${CONFIG_IFPARSE}_OBJ += ${IFPARSE_SRC:.c=.o}
 CMDS_${CONFIG_IFPARSE} += ifparse
 
+# enable libmnl support
+CONFIG_LIBMNL ?= N
+LIBIFUPDOWN_LIBMNL_Y_SRC = libifupdown/waitif_libmnl.c
+LIBIFUPDOWN_LIBMNL_N_SRC = libifupdown/waitif_stub.c
+LIBIFUPDOWN_LIBMNL_${CONFIG_LIBMNL}_LIBS = -pthread
+LIBMNL_SRC = ${LIBIFUPDOWN_LIBMNL_${CONFIG_LIBMNL}_SRC}
+
+LIBIFUPDOWN_OBJ += ${LIBMNL_SRC:.c=.o}
+LIBS += ${LIBIFUPDOWN_LIBMNL_Y_LIBS}
+
 # enable YAML support (+2 KB)
 CONFIG_YAML ?= Y
 YAML_SRC = \
@@ -121,7 +134,7 @@ EXECUTOR_SCRIPTS_STUB ?=
 EXECUTOR_SCRIPTS_NATIVE ?=
 
 TARGET_LIBS = ${LIBIFUPDOWN_LIB}
-LIBS += ${TARGET_LIBS} ${LIBBSD_LIBS}
+LIBS += ${TARGET_LIBS} ${LIBBSD_LIBS} ${LIBMNL_LIBS}
 
 all: ${MULTICALL} ${CMDS}
 

--- a/cmd/ifupdown.c
+++ b/cmd/ifupdown.c
@@ -255,6 +255,7 @@ ifupdown_main(int argc, char *argv[])
 	};
 
 	lif_interface_collection_init(&collection);
+	lif_waitif_init();
 
 	if (!lif_state_read_path(&state, exec_opts.state_file))
 	{

--- a/executor-scripts/linux/link
+++ b/executor-scripts/linux/link
@@ -80,7 +80,7 @@ create)
 		${MOCK} ip link add link "${IF_VLAN_RAW_DEVICE}" name "${IFACE}" type vlan id "${IF_VLAN_ID}"
 	fi
 	;;
-up)
+pre-up)
 	IF_LINK_OPTIONS="$IF_LINK_OPTIONS"
 	[ -n "$IF_MTU" ] && IF_LINK_OPTIONS="$IF_LINK_OPTIONS mtu $IF_MTU"
 	[ -n "$IF_HWADDRESS" ] && IF_LINK_OPTIONS="$IF_LINK_OPTIONS address $IF_HWADDRESS"

--- a/libifupdown/libifupdown.h
+++ b/libifupdown/libifupdown.h
@@ -30,6 +30,7 @@
 #include "libifupdown/config-file.h"
 #include "libifupdown/config-parser.h"
 #include "libifupdown/compat.h"
+#include "libifupdown/waitif.h"
 
 #ifndef ARRAY_SIZE
 # define ARRAY_SIZE(x)   (sizeof(x) / sizeof(*x))

--- a/libifupdown/lifecycle.c
+++ b/libifupdown/lifecycle.c
@@ -435,8 +435,6 @@ handle_dependents(const struct lif_execute_opts *opts, struct lif_interface *par
 bool
 lif_lifecycle_run(const struct lif_execute_opts *opts, struct lif_interface *iface, struct lif_dict *collection, struct lif_dict *state, const char *lifname, bool up)
 {
-	struct waitif_iface wif;
-
 	/* if we're already pending, exit */
 	if (iface->is_pending)
 		return true;
@@ -460,6 +458,7 @@ lif_lifecycle_run(const struct lif_execute_opts *opts, struct lif_interface *ifa
 		if (!lif_lifecycle_run_phase(opts, iface, "create", lifname, up))
 			return false;
 
+		struct waitif_iface wif;
 		if (!lif_waitif_setup(&wif, lifname))
 			return false;
 		if (!lif_lifecycle_run_phase(opts, iface, "pre-up", lifname, up))

--- a/libifupdown/waitif.h
+++ b/libifupdown/waitif.h
@@ -2,10 +2,7 @@
 #define LIBIFUPDOWN_WAITIF_H__GUARD
 
 #include <stdbool.h>
-#include <pthread.h>
-#include <sys/sem.h>
 #include <semaphore.h>
-#include <libmnl/libmnl.h>
 
 #include "libifupdown/dict.h"
 

--- a/libifupdown/waitif.h
+++ b/libifupdown/waitif.h
@@ -13,6 +13,6 @@ struct waitif_iface {
 
 extern bool lif_waitif_init(void);
 extern bool lif_waitif_setup(struct waitif_iface *iface, const char *name);
-extern bool lif_waitif_wait(struct waitif_iface *iface, int timeout);
+extern bool lif_waitif_wait(struct waitif_iface *iface, unsigned timeout);
 
 #endif

--- a/libifupdown/waitif.h
+++ b/libifupdown/waitif.h
@@ -1,0 +1,21 @@
+#ifndef LIBIFUPDOWN_WAITIF_H__GUARD
+#define LIBIFUPDOWN_WAITIF_H__GUARD
+
+#include <stdbool.h>
+#include <pthread.h>
+#include <sys/sem.h>
+#include <semaphore.h>
+#include <libmnl/libmnl.h>
+
+#include "libifupdown/dict.h"
+
+struct waitif_iface {
+	int target_state;
+	sem_t sema;
+};
+
+extern bool lif_waitif_init(void);
+extern bool lif_waitif_setup(struct waitif_iface *iface, const char *name);
+extern bool lif_waitif_wait(struct waitif_iface *iface, int timeout);
+
+#endif

--- a/libifupdown/waitif.h
+++ b/libifupdown/waitif.h
@@ -4,8 +4,6 @@
 #include <stdbool.h>
 #include <semaphore.h>
 
-#include "libifupdown/dict.h"
-
 struct waitif_iface {
 	int target_state;
 	sem_t sema;

--- a/libifupdown/waitif_libmnl.c
+++ b/libifupdown/waitif_libmnl.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <errno.h>
 #include <string.h>
+#include <pthread.h>
 #include <sys/types.h>
 
 #include <net/if.h>

--- a/libifupdown/waitif_libmnl.c
+++ b/libifupdown/waitif_libmnl.c
@@ -112,14 +112,14 @@ lif_waitif_setup(struct waitif_iface *iface, const char *name)
 }
 
 bool
-lif_waitif_wait(struct waitif_iface *wif, unsigned timeout)
+lif_waitif_wait(struct waitif_iface *iface, unsigned timeout)
 {
 	struct timespec ts;
 
 	if (clock_gettime(CLOCK_REALTIME, &ts))
 		return false;
 	ts.tv_sec += timeout;
-	if (sem_timedwait(&wif->sema, &ts) == -1)
+	if (sem_timedwait(&iface->sema, &ts) == -1)
 		return false;
 
 	return true;

--- a/libifupdown/waitif_libmnl.c
+++ b/libifupdown/waitif_libmnl.c
@@ -59,7 +59,7 @@ netlink_cb(const struct nlmsghdr *nlh, void *arg)
 static void *
 netlink_loop(void *arg)
 {
-	static char buf[8192];
+	char buf[MNL_SOCKET_BUFFER_SIZE];
 	struct waitif_listener *ln = (struct waitif_listener*)arg;
 
 	ssize_t ret = mnl_socket_recvfrom(listener.nl, buf, sizeof(buf));

--- a/libifupdown/waitif_libmnl.c
+++ b/libifupdown/waitif_libmnl.c
@@ -1,0 +1,125 @@
+#include <time.h>
+#include <stdio.h>
+#include <errno.h>
+#include <string.h>
+#include <sys/types.h>
+
+#include <net/if.h>
+#include <libmnl/libmnl.h>
+#include <linux/if.h>
+#include <linux/if_link.h>
+#include <linux/rtnetlink.h>
+
+#include "libifupdown/waitif.h"
+
+struct waitif_listener {
+	pthread_t pthread;
+	pthread_mutex_t mtx;
+	struct lif_dict ifs;
+};
+
+/* Only one listener will be needed for ifupdown, thus global. */
+static struct waitif_listener listener;
+
+static int
+netlink_cb(const struct nlmsghdr *nlh, void *arg)
+{
+	struct waitif_listener *ln = (struct waitif_listener *)arg;
+
+	struct ifinfomsg *ifm;
+	ifm = mnl_nlmsg_get_payload(nlh);
+
+	char ifname[IF_NAMESIZE];
+	if (!if_indextoname(ifm->ifi_index, ifname)) {
+		fprintf(stderr, "ifupdown: if_indextoname failed for interface %d: %s\n", ifm->ifi_index, strerror(errno));
+		return MNL_CB_OK; /* continue processing other ifaces */
+	}
+
+	pthread_mutex_lock(&ln->mtx);
+	struct lif_dict_entry *entry;
+	if (!(entry = lif_dict_find(&ln->ifs, ifname)))
+		return MNL_CB_OK; /* no link state handling requested */
+
+	struct waitif_iface *iface;
+	iface = (struct waitif_iface *)entry->data;
+	if (ifm->ifi_flags & iface->target_state)
+		sem_post(&iface->sema);
+	lif_dict_delete(&ln->ifs, ifname);
+	pthread_mutex_unlock(&ln->mtx);
+
+	return MNL_CB_OK;
+}
+
+static void *
+netlink_loop(void *arg)
+{
+	char buf[MNL_SOCKET_BUFFER_SIZE];
+
+	struct waitif_listener *ln;
+	ln = (struct waitif_listener *)arg;
+
+	struct mnl_socket *nl;
+	nl = mnl_socket_open(NETLINK_ROUTE);
+	if (nl == NULL)
+		goto err0;
+	if (mnl_socket_bind(nl, RTMGRP_LINK, MNL_SOCKET_AUTOPID) < 0)
+		goto err1;
+
+	ssize_t ret = mnl_socket_recvfrom(nl, buf, sizeof(buf));
+	while (ret > 0) {
+		ret = mnl_cb_run(buf, (size_t)ret, 0, 0, netlink_cb, (void *)ln);
+		if (ret <= 0)
+			break;
+		ret = mnl_socket_recvfrom(nl, buf, sizeof(buf));
+	}
+	if (ret == -1)
+		goto err1;
+
+err1:
+	mnl_socket_close(nl);
+err0:
+	fprintf(stderr, "ifupdown: netlink_loop failed %s\n", strerror(errno));
+	return NULL;
+}
+
+bool
+lif_waitif_init(void)
+{
+	lif_dict_init(&listener.ifs);
+	if (pthread_mutex_init(&listener.mtx, NULL))
+		return false;
+	if (pthread_create(&listener.pthread, NULL, netlink_loop, &listener))
+		return false;
+
+	return true;
+}
+
+bool
+lif_waitif_setup(struct waitif_iface *iface, const char *name)
+{
+	iface->target_state = IFF_RUNNING; /* XXX: Make this configurable? */
+	if (sem_init(&iface->sema, 1, 0))
+		return false;
+
+	if (pthread_mutex_lock(&listener.mtx))
+		return false;
+	lif_dict_add(&listener.ifs, name, iface);
+	if (pthread_mutex_unlock(&listener.mtx))
+		return false;
+
+	return true;
+}
+
+bool
+lif_waitif_wait(struct waitif_iface *wif, int timeout)
+{
+	struct timespec ts;
+
+	if (clock_gettime(CLOCK_REALTIME, &ts))
+		return false;
+	ts.tv_sec += timeout;
+	if (sem_timedwait(&wif->sema, &ts) == -1)
+		return false;
+
+	return true;
+}

--- a/libifupdown/waitif_libmnl.c
+++ b/libifupdown/waitif_libmnl.c
@@ -112,7 +112,7 @@ lif_waitif_setup(struct waitif_iface *iface, const char *name)
 }
 
 bool
-lif_waitif_wait(struct waitif_iface *wif, int timeout)
+lif_waitif_wait(struct waitif_iface *wif, unsigned timeout)
 {
 	struct timespec ts;
 

--- a/libifupdown/waitif_libmnl.c
+++ b/libifupdown/waitif_libmnl.c
@@ -15,8 +15,8 @@
 
 struct waitif_listener {
 	pthread_t pthread;
-	pthread_mutex_t ifs_mtx;
 	struct lif_dict ifs;
+	pthread_mutex_t ifs_mtx;
 };
 
 /* Only one listener will be needed for ifupdown, thus global. */

--- a/libifupdown/waitif_libmnl.c
+++ b/libifupdown/waitif_libmnl.c
@@ -116,10 +116,10 @@ bool
 lif_waitif_wait(struct waitif_iface *iface, unsigned timeout)
 {
 	struct timespec ts;
-
 	if (clock_gettime(CLOCK_REALTIME, &ts))
 		return false;
 	ts.tv_sec += timeout;
+
 	if (sem_timedwait(&iface->sema, &ts) == -1)
 		return false;
 

--- a/libifupdown/waitif_libmnl.c
+++ b/libifupdown/waitif_libmnl.c
@@ -11,6 +11,7 @@
 #include <linux/if_link.h>
 #include <linux/rtnetlink.h>
 
+#include "libifupdown/dict.h"
 #include "libifupdown/waitif.h"
 
 struct waitif_listener {

--- a/libifupdown/waitif_stub.c
+++ b/libifupdown/waitif_stub.c
@@ -16,9 +16,9 @@ lif_waitif_setup(struct waitif_iface *iface, const char *name)
 }
 
 bool
-lif_waitif_wait(struct waitif_iface *wif, unsigned timeout)
+lif_waitif_wait(struct waitif_iface *iface, unsigned timeout)
 {
-	(void) wif;
+	(void) iface;
 	(void) timeout;
 
 	return true;

--- a/libifupdown/waitif_stub.c
+++ b/libifupdown/waitif_stub.c
@@ -16,7 +16,7 @@ lif_waitif_setup(struct waitif_iface *iface, const char *name)
 }
 
 bool
-lif_waitif_wait(struct waitif_iface *wif, int timeout)
+lif_waitif_wait(struct waitif_iface *wif, unsigned timeout)
 {
 	(void) wif;
 	(void) timeout;

--- a/libifupdown/waitif_stub.c
+++ b/libifupdown/waitif_stub.c
@@ -1,0 +1,25 @@
+#include "libifupdown/waitif.h"
+
+bool
+lif_waitif_init(void)
+{
+	return true;
+}
+
+bool
+lif_waitif_setup(struct waitif_iface *iface, const char *name)
+{
+	(void) iface;
+	(void) name;
+
+	return true;
+}
+
+bool
+lif_waitif_wait(struct waitif_iface *wif, int timeout)
+{
+	(void) wif;
+	(void) timeout;
+
+	return true;
+}


### PR DESCRIPTION
As proposed in #178, this PR adds optional link state detection support to `ifupdown-ng` via [libmnl](https://www.netfilter.org/projects/libmnl/). As it requires an external dependency (libmnl), this new feature is entirely optional and disabled by default. In order to enable this feature, compile `ifupdown-ng` as follows:

```
$  make CONFIG_LIBMNL=Y LIBMNL_CFLAGS=$(pkg-config --cflags libmnl) LIBMNL_LIBS=$(pkg-config --libs libmnl)
```

When compiled this way, the `ifup` command will block after the `pre-up` phase until the configured interface switched to the `IFF_RUNNING` state (see `netdevice(7)`) (**TODO:** Should the state be configurable? Is `IFF_UP` the preferable state?). This is currently unconditional enabled for all interface types (**TODO:** Is this a good idea?). This ensures that all executors of the `up` phase are *only* executed if the interface is up & running and not before that (see #178 for why this might be preferable) (**TODO**: Should this be mentioned in `ifupdown-executor(7)`?). If the interface doesn't change to the desired state within a specified timeout (**TODO:** Make this timeout configurable) then up'ing the interface fails.

I decided to implement this feature directly in libifupdown instead of using [a separate executor](
https://github.com/nmeum/ifupdown-ng-waitif) for the following reason: (1) Eases satisfying interface state before `up` executors are run (by blocking after `pre-up`) (2) allows re-using the same listener event loop across different interfaces.

Thoughts?

---

Fixes #178 