### PR TITLE
Makefile: Pick up LDFLAGS variable when linking multicall binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ ${CMDS}: ${MULTICALL}
 	ln -sf ifupdown $@
 
 ${MULTICALL}: ${TARGET_LIBS} ${MULTICALL_OBJ}
-	${CC} -o $@ ${MULTICALL_OBJ} ${LIBS}
+	${CC} ${LDFLAGS} -o $@ ${MULTICALL_OBJ} ${LIBS}
 
 ${LIBIFUPDOWN_LIB}: ${LIBIFUPDOWN_OBJ}
 	${AR} -rcs $@ ${LIBIFUPDOWN_OBJ}


### PR DESCRIPTION
This is a well known variable set by many Linux distributions (e.g. Alpine). Without this change, the ifupdown-ng build system does not pick up linker flags passed via LDFLAGS.