### PR TITLE
add support for ipv6 temporary SLAAC addresses

### DIFF
--- a/executor-scripts/linux/ipv6-tempaddr
+++ b/executor-scripts/linux/ipv6-tempaddr
@@ -1,0 +1,16 @@
+#!/bin/sh
+start() {
+	${MOCK} /bin/sh -c "echo 2 > /proc/sys/net/ipv6/conf/$IFACE/use_tempaddr"
+}
+
+stop() {
+	${MOCK} /bin/sh -c "echo 0 > /proc/sys/net/ipv6/conf/$IFACE/use_tempaddr"
+}
+
+[ -z "$VERBOSE" ] || set -x
+
+case "$PHASE" in
+pre-up) start $impl ;;
+pre-down) stop $impl ;;
+*) ;;
+esac

--- a/tests/linux/Kyuafile
+++ b/tests/linux/Kyuafile
@@ -8,6 +8,7 @@ atf_test_program{name='ethtool_test'}
 atf_test_program{name='forward_test'}
 atf_test_program{name='gre_test'}
 atf_test_program{name='ipv6-ra_test'}
+atf_test_program{name='ipv6-tempaddr_test'}
 atf_test_program{name='link_test'}
 atf_test_program{name='mpls_test'}
 atf_test_program{name='ppp_test'}

--- a/tests/linux/ipv6-tempaddr_test
+++ b/tests/linux/ipv6-tempaddr_test
@@ -1,0 +1,18 @@
+#!/usr/bin/env atf-sh
+
+. $(atf_get_srcdir)/../test_env.sh
+EXECUTOR="$(atf_get_srcdir)/../../executor-scripts/linux/ipv6-tempaddr"
+
+tests_init pre_up pre_down
+
+pre_up_body() {
+	export IFACE=lo PHASE=pre-up MOCK=echo MOCK_ESC=\\
+	atf_check -s exit:0 -o match:'echo 2 > /proc/sys/net/ipv6/conf/lo/use_tempaddr' \
+		${EXECUTOR}
+}
+
+pre_down_body() {
+	export IFACE=lo PHASE=pre-down MOCK=echo MOCK_ESC=\\
+	atf_check -s exit:0 -o match:'echo 0 > /proc/sys/net/ipv6/conf/lo/use_tempaddr' \
+		${EXECUTOR}
+}


### PR DESCRIPTION
Add an executor `ipv6-tempaddr` that enables the `use_tempaddr` kernel flag to generate RFC 4941 IPv6 temporary addresses.

RFC 4941 is already obsoleted by 8981 but that does not appear to be implemented in the Linux kernel yet. I still think it's useful and easy to support this. It should also be easy to support the newer RFC when it's available.