### PR TITLE
Fix vrf ip rule for kernels equal or greater than 4.8

### DIFF
--- a/executor-scripts/linux/vrf
+++ b/executor-scripts/linux/vrf
@@ -1,8 +1,21 @@
 #!/bin/sh
+kernel_version_48() {
+	local kver="$(uname -r)"
+	local kverMaj="$(echo $kver | sed 's/\([0-9]\+\)\.\([0-9]\+\).*/\1/')"
+	local kverMin="$(echo $kver | sed 's/\([0-9]\+\)\.\([0-9]\+\).*/\2/')"
+
+	if [ "$kverMaj" -le 4 -a "$kverMin" -lt 8 ]; then
+		return 0
+	fi
+	return 1
+}
+
 handle_init() {
 	${MOCK} /sbin/ip link $1 $IFACE type vrf table $IF_VRF_TABLE
-	${MOCK} /sbin/ip rule $1 iif $IFACE table $IF_VRF_TABLE
-	${MOCK} /sbin/ip rule $1 oif $IFACE table $IF_VRF_TABLE
+	if kernel_version_48; then
+		${MOCK} /sbin/ip rule $1 iif $IFACE table $IF_VRF_TABLE
+		${MOCK} /sbin/ip rule $1 oif $IFACE table $IF_VRF_TABLE
+	fi
 }
 
 handle_member() {


### PR DESCRIPTION
Hi,
I've notice that each time I'm creating a VRF I will have some additional **ip rules** like this:

```
# ip rule list
0:	from all lookup local
216:	from all oif vrf01 lookup 3000
217:	from all iif vrf01 lookup 3000
218:	from all oif vrf01 lookup 3000
219:	from all iif vrf01 lookup 3000
220:	from all lookup 220
1000:	from all lookup [l3mdev-table]
32766:	from all lookup main
32767:	from all lookup default
```

Which are not valid anymore if you have a Kernel greater than 4.7. In Kernel documentation is specified:
```
2. An l3mdev FIB rule directs lookups to the table associated with the device.
   A single l3mdev rule is sufficient for all VRFs. The VRF device adds the
   l3mdev rule for IPv4 and IPv6 when the first device is created with a
   default preference of 1000. Users may delete the rule if desired and add
   with a different priority or install per-VRF rules.

   Prior to the v4.8 kernel iif and oif rules are needed for each VRF device:
       ip ru add oif vrf-blue table 10
       ip ru add iif vrf-blue table 10
```
This patch is checking the major and minor Kernel version and it will adds these rules only if you have a Kernel lower than 4.8.
