### PR TITLE
Load the dummy kernel module

### DIFF
--- a/executor-scripts/linux/link
+++ b/executor-scripts/linux/link
@@ -39,7 +39,6 @@ depend)
 create)
 	if [ "${IF_LINK_TYPE}" = "dummy" ]; then
 		if [ ! -d /sys/module/dummy ]; then
-			echo "Loading dummy kernel module"
 			${MOCK} modprobe dummy
 		fi
 

--- a/executor-scripts/linux/link
+++ b/executor-scripts/linux/link
@@ -38,6 +38,11 @@ depend)
 
 create)
 	if [ "${IF_LINK_TYPE}" = "dummy" ]; then
+		if [ ! -d /sys/module/dummy ]; then
+			echo "Loading dummy kernel module"
+			${MOCK} modprobe dummy
+		fi
+
 		if [ -d "/sys/class/net/${IFACE}" ]; then
 			iface_type=$(ip -d link show dev "${IFACE}" | head -n3 | tail -n1 | awk '{ print $1 }')
 			if [ "${iface_type}" != 'dummy' ]; then


### PR DESCRIPTION
Fixes https://github.com/ifupdown-ng/ifupdown-ng/issues/184.

A `dummy0` interface is automatically created when loading the `dummy` kernel module. This presents a problem should the kernel module be loaded as a result of a `ip link add dummy0 type dummy`, as the command fails due to `dummy0 `suddenly existing as a result of the integrated kernel module load:

```
$ ip link add dummy0 type dummy
ip: RTNETLINK answers: File exists
```

By loading the kernel module separately, the `dummy0` interface is detected thanks to the presence of `/sys/class/net/dummy0` and reused should `dummy0` be specified as the interface name with ifupdown-ng.