### PR TITLE
dummy: Verify the interface is virtual

### DIFF
--- a/executor-scripts/linux/link
+++ b/executor-scripts/linux/link
@@ -39,9 +39,8 @@ depend)
 create)
 	if [ "${IF_LINK_TYPE}" = "dummy" ]; then
 		if [ -d "/sys/class/net/${IFACE}" ]; then
-			iface_type=$(ip -d link show dev "${IFACE}" | head -n3 | tail -n1 | awk '{ print $1 }')
-			if [ "${iface_type}" != 'dummy' ]; then
-				echo "Interface ${IFACE} exists but is of type ${iface_type} instead of dummy"
+			if [ ! -d "/sys/devices/virtual/net/${IFACE}" ]; then
+				echo "Interface ${IFACE} exists but is not a virtual interface"
 				exit 1
 			fi
 


### PR DESCRIPTION
This is one possible solution to the issue raised in https://github.com/ifupdown-ng/ifupdown-ng/pull/54#discussion_r922671069.

While not as perfect as the previous approach, this will work with Busybox's implementation of `ip`, which doesn't support the `-d` flag.

/cc @BarbarossaTM @kaniini 

