### PR TITLE
VRF shutdown fix

### DIFF
--- a/executor-scripts/linux/vrf
+++ b/executor-scripts/linux/vrf
@@ -22,6 +22,10 @@ handle_member() {
 	${MOCK} /sbin/ip link set $IFACE master $IF_VRF_MEMBER
 }
 
+handle_member_off() {
+	${MOCK} /sbin/ip link set $IFACE nomaster
+}
+
 [ -n "$VERBOSE" ] && set -x
 
 case "$PHASE" in
@@ -30,6 +34,9 @@ create)
 	;;
 pre-up)
 	[ -n "$IF_VRF_MEMBER" ] && handle_member
+	;;
+post-down)
+	[ -n "$IF_VRF_MEMBER" ] && handle_member_off
 	;;
 destroy)
 	[ -n "$IF_VRF_TABLE" ] && handle_init "del"


### PR DESCRIPTION
### Interface under VRF shutdown fix

I notice that when I shutdown an interface which is part of a VRF, the script is not removing the interface from the VRF.
That leads sometimes to some issue if you want to reuse that interface for other purpose in global VRF. If you reconfigure the interface and try to rerun the ifup for that interface under global VRF which previously was under a VRF, you will notice that the interface is still have the master the prevoius VRF.
Normally if you shutdown an interface and is a physical one, not a virtual one, should go back to default VRF.