### PR TITLE
static executor: add "onlink" option for default route

### DIFF
--- a/executor-scripts/linux/static
+++ b/executor-scripts/linux/static
@@ -33,7 +33,7 @@ configure_addresses() {
 configure_gateways() {
 	for gw in ${IF_GATEWAYS}; do
 		addrfam=$(addr_family ${gw})
-		${MOCK} ip "${addrfam}" route add default via "${gw}" ${VRF_TABLE} ${METRIC} dev "${IFACE}"
+		${MOCK} ip "${addrfam}" route add default via "${gw}" ${VRF_TABLE} ${METRIC} dev "${IFACE}" onlink
 	done
 }
 


### PR DESCRIPTION
Add the "onlink" next-hop option to the default route. This is required for situations like some VPS/Cloud Providers where they provide a /32 IPv4 address or a /128 IPv6 address and obviously the router to use as the gateway for the default route is not in the same subnet.

Debian's ifupdown package has been adding the "onlink" option for the past 7 years.

https://salsa.debian.org/debian/ifupdown/-/commit/8b7bca9597d2f75670b182f0fc149cdbaec3544c