### PR TITLE
Fix VRF executor exit code for ifupdown-ng 0.12.1 - CRITICAL

### DIFF
--- a/executor-scripts/linux/vrf
+++ b/executor-scripts/linux/vrf
@@ -45,6 +45,7 @@ depend)
 	echo "$IF_VRF_MEMBER"
 	;;
 *)
-	exit 0
 	;;
 esac
+
+exit 0


### PR DESCRIPTION
Fix the exit codes for VRF executor. In 0.12.1 the forked executor must exits with 0 to be able for ifupdown to continue with the rest of the configuration.

This fixes #211 bug.

In case of using without this fix and ifupdown-ng is used in a router, this could lead to unbootable system!

This fix should be treated as critical.