### PR TITLE
Fix Debian systemd service - URGENT

### DIFF
--- a/dist/debian/ifupdown-ng.networking.service
+++ b/dist/debian/ifupdown-ng.networking.service
@@ -9,7 +9,7 @@ SyslogIdentifier=networking
 TimeoutStopSec=30s
 ExecStart=/usr/share/ifupdown-ng/sbin/networking start
 ExecStop=/usr/share/ifupdown-ng/sbin/networking stop
-ExecRestart=/usr/share/ifupdown-ng/sbin/networking restart
+ExecReload=/usr/share/ifupdown-ng/sbin/networking restart
 
 [Install]
 WantedBy=basic.target network.target multi-user.target network-online.target


### PR DESCRIPTION
This PR is fixing the startup service for Systemd.

The service was created with ExecRestart which in systemd documentation doesn't exist!
Looks like for a period of time the service worked with this error, but in Debian Trixie the service stops to work anymore.
It fails with **Unknown key name 'ExecRestart' in section 'Service'**

Please push this PR ASAP because can cause no network on Linux starts.