### PR TITLE
Fix missing strlcpy with BSD string library - URGENT - failed to compile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 LAYOUT ?= linux
 SCDOC := scdoc
 LIBBSD_CFLAGS =
-LIBBSD_LIBS =
+LIBBSD_LIBS = -lbsd
 
 PACKAGE_NAME := ifupdown-ng
 PACKAGE_VERSION := 0.12.1

--- a/cmd/ifquery.c
+++ b/cmd/ifquery.c
@@ -16,7 +16,7 @@
 #define _GNU_SOURCE
 #include <fnmatch.h>
 #include <stdio.h>
-#include <string.h>
+#include <bsd/string.h>
 #include <getopt.h>
 #include "libifupdown/libifupdown.h"
 #include "cmd/multicall.h"

--- a/cmd/ifupdown.c
+++ b/cmd/ifupdown.c
@@ -17,7 +17,7 @@
 #define _GNU_SOURCE
 #include <fnmatch.h>
 #include <stdio.h>
-#include <string.h>
+#include <bsd/string.h>
 #include <getopt.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/libifupdown/compat.c
+++ b/libifupdown/compat.c
@@ -15,7 +15,7 @@
 
 #include <stdbool.h>
 #include <stdio.h>
-#include <string.h>
+#include <bsd/string.h>
 #include "libifupdown/compat.h"
 #include "libifupdown/config-file.h"
 #include "libifupdown/dict.h"

--- a/libifupdown/interface-file.c
+++ b/libifupdown/interface-file.c
@@ -17,7 +17,7 @@
 #include <ctype.h>
 #include <stdarg.h>
 #include <stdio.h>
-#include <string.h>
+#include <bsd/string.h>
 #include <dirent.h>
 #include <errno.h>
 #include <sys/stat.h>

--- a/libifupdown/interface.c
+++ b/libifupdown/interface.c
@@ -15,7 +15,7 @@
  */
 
 #include <stdio.h>
-#include <string.h>
+#include <bsd/string.h>
 #include <sys/utsname.h>
 #include "libifupdown/interface.h"
 #include "libifupdown/config-file.h"

--- a/libifupdown/lifecycle.c
+++ b/libifupdown/lifecycle.c
@@ -15,7 +15,7 @@
  */
 
 #include <ctype.h>
-#include <string.h>
+#include <bsd/string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>


### PR DESCRIPTION
Hi,

Starting with Debian Trixie ifupdown-ng fails to compile with this error:

```
cc -ggdb3 -Os -Wall -Wextra -Werror -Wmissing-declarations -Wmissing-prototypes -Wcast-align -Wpointer-arith -Wreturn-type  -I. -DINTERFACES_FILE=\"/etc/network/interfaces\" -DSTATE_FILE=\"/run/ifstate\" -DCONFIG_FILE=\"/etc/network/ifupdown-ng.conf\" -DPACKAGE_NAME=\"ifupdown-ng\" -DPACKAGE_VERSION=\"0.12.1\" -DPACKAGE_BUGREPORT=\"https://github.com/ifupdown-ng/ifupdown-ng/issues/new\" -DEXECUTOR_PATH=\"/usr/libexec/ifupdown-ng\" -DCONFIG_YAML  -c -o libifupdown/interface.o libifupdown/interface.c
libifupdown/interface.c: In function ‘lif_address_parse’:
libifupdown/interface.c:28:9: error: implicit declaration of function ‘strlcpy’; did you mean ‘strncpy’? [-Werror=implicit-function-declaration]
   28 |         strlcpy(buf, presentation, sizeof buf);
      |         ^~~~~~~
      |         strncpy
cc1: all warnings being treated as errors
make: *** [<builtin>: libifupdown/interface.o] Error 1
```

Checking strlcpy function it doesn't belongs to <string.h>, instead <bsd/string.h> must be used to fix the error.
Also -lbsd must be included in Makefile.

