### PR TITLE
Fix GRE tests

### DIFF
--- a/tests/linux/gre_test
+++ b/tests/linux/gre_test
@@ -14,7 +14,7 @@ basic_bringup_body() {
 		IF_GRE_TTL=255
 	atf_check -s exit:0 \
 		-o match:"ip -4 link add tun0" \
-		-o match:"mode gre" \
+		-o match:"type gre" \
 		-o match:"ttl '255'" \
 		-o match:"local '1.2.3.4'" \
 		-o match:"remote '5.6.7.8'" \
@@ -36,7 +36,7 @@ flags_bringup_body() {
 		IF_GRE_TTL=255 IF_GRE_FLAGS="nopmtudisc ignore-df"
 	atf_check -s exit:0 \
 		-o match:"ip -4 link add tun0" \
-		-o match:"mode gre" \
+		-o match:"type gre" \
 		-o match:"ttl '255'" \
 		-o match:"local '1.2.3.4'" \
 		-o match:"remote '5.6.7.8'" \


### PR DESCRIPTION
Hi,
Please push this PR because when I'm trying to compile under Debian using dpkg-buildpackage is failing with 2 tests:

```
===> tests/linux/gre_test:basic_bringup
Result:     failed: atf-check failed; see the output of the test for details
Start time: 2023-09-07T06:58:31.479501Z
End time:   2023-09-07T06:58:31.522489Z
Duration:   0.043s

Metadata:
    allowed_architectures is empty
    allowed_platforms is empty
    description is empty
    has_cleanup = false
    is_exclusive = false
    required_configs is empty
    required_disk_space = 0
    required_files is empty
    required_memory = 0
    required_programs is empty
    required_user is empty
    timeout = 300

Standard output:
Executing command [ /opt/devel/ifupdown-ng/Debian/ifupdown-ng-0.14.0~easynet1/tests/linux/../../executor-scripts/linux/gre ]

Standard error:
Fail: regexp mode gre not in stdout
eval ip -4 link add tun0 type gre local '1.2.3.4' remote '5.6.7.8' ttl '255'
===> tests/linux/gre_test:flags_bringup
Result:     failed: atf-check failed; see the output of the test for details
Start time: 2023-09-07T06:58:31.568032Z
End time:   2023-09-07T06:58:31.610711Z
Duration:   0.043s

Metadata:
    allowed_architectures is empty
    allowed_platforms is empty
    description is empty
    has_cleanup = false
    is_exclusive = false
    required_configs is empty
    required_disk_space = 0
    required_files is empty
    required_memory = 0
    required_programs is empty
    required_user is empty
    timeout = 300

Standard output:
Executing command [ /opt/devel/ifupdown-ng/Debian/ifupdown-ng-0.14.0~easynet1/tests/linux/../../executor-scripts/linux/gre ]

Standard error:
Fail: regexp mode gre not in stdout
eval ip -4 link add tun0 type gre local '1.2.3.4' remote '5.6.7.8' ttl '255' nopmtudisc ignore-df
===> Failed tests
tests/linux/gre_test:basic_bringup  ->  failed: atf-check failed; see the output of the test for details  [0.043s]
tests/linux/gre_test:flags_bringup  ->  failed: atf-check failed; see the output of the test for details  [0.043s]
===> Summary
Results read from /tmp/.kyua/store/results.opt_devel_ifupdown-ng_Debian_ifupdown-ng-0.14.0~easynet1.20230907-065820-690875.db
Test cases: 187 total, 0 skipped, 0 expected failures, 0 broken, 2 failed
Start time: 2023-09-07T06:58:21.088510Z
End time:   2023-09-07T06:58:34.007643Z
Total time: 10.315s
make[2]: *** [Makefile:158: check] Error 1
make[2]: Leaving directory '/opt/devel/ifupdown-ng/Debian/ifupdown-ng-0.14.0~easynet1'
dh_auto_test: error: make -j8 check returned exit code 2
make[1]: *** [debian/rules:28: override_dh_auto_test] Error 2
make[1]: Leaving directory '/opt/devel/ifupdown-ng/Debian/ifupdown-ng-0.14.0~easynet1'
make: *** [debian/rules:8: binary] Error 2
dpkg-buildpackage: error: debian/rules binary subprocess returned exit status 2
adrian@RouterFW:/opt/devel/ifupdown-ng/Debian/ifupdown-ng-0.14.0~easynet1$
adrian@RouterFW:/opt/devel/ifupdown-ng/Debian/ifupdown-ng-0.14.0~easynet1$ less tests/linux/gre_test
adrian@RouterFW:/opt/devel/ifupdown-ng/Debian/ifupdown-ng-0.14.0~easynet1$
adrian@RouterFW:/opt/devel/ifupdown-ng$ mkdir 20230907-fix-gre-tests
adrian@RouterFW:/opt/devel/ifupdown-ng$
adrian@RouterFW:/opt/devel/ifupdown-ng/20230907-fix-gre-tests$ git clone https://github.com/ifupdown-ng/ifupdown-ng .
Cloning into '.'...
remote: Enumerating objects: 3557, done.
remote: Counting objects: 100% (532/532), done.
remote: Compressing objects: 100% (250/250), done.
remote: Total 3557 (delta 304), reused 478 (delta 282), pack-reused 3025
Receiving objects: 100% (3557/3557), 605.03 KiB | 3.88 MiB/s, done.
Resolving deltas: 100% (2311/2311), done.
```
