### PR TITLE
VRRP v1.3 using CRC32

### DIFF
--- a/doc/interfaces-vrrp.scd
+++ b/doc/interfaces-vrrp.scd
@@ -1,0 +1,200 @@
+interfaces-vrrp(5)
+
+# NAME
+
+*interfaces-vrrp* - VRRP extensions for the interfaces(5) file format
+
+# DESCRIPTION
+
+VRRP stands for Virtual Router Redundancy Protocol. This protocol 
+is used to allow multiple backup routers on the same segment to take 
+over operation of each others’ IP addresses if the primary router fails. 
+This is typically used to provide fault-tolerant gateways to hosts 
+on the segment.
+
+Linux has support for MACVLAN from version *3.0*, but the _protodown_ 
+property appears only in kernel *5.1*. Don't try to use this setup for
+kernels older than *5.1*. It will not work.
+
+To be able to use VRRP you need to run an user-space software that 
+manages the Master-Backup setup. A good example is FFRouting software 
+which includes the VRRP daemon.
+
+*Note*: for each type of traffic *IPv4* or *IPv6* you need a complete different 
+interface. For one _main interface_ where you have dual-stack traffic 
+you will need 2 VRRP interfaces: one for IPv4 and one for IPv6.
+For this reason 2 addtitional interfaces are needed because each protocol 
+needs its separate MAC address for that specific traffic. That's why you 
+can't use only one VRRP interface for both IPv4 and IPv6 traffic.
+
+Convention of the name is *vXXXXXXXX-YY-V*, where *XXXXXXXX* is CRC32 value in HEX 
+calculated from main *interface name*. *YY* is the *VRRP ID*. *V* stands for protocol 
+version: *4* for *IPv4* and *6* for *IPv6*.
+
+There are 2 ways to use CRC32: crc32b tool that is provider with ifupdown-ng 
+or cksum provided by coreutils. The script is searching first for crc32b and 
+then for cksum.
+
+*Be aware* that _crc32b_ and _cksum_ are not giving you the same output!
+If the tools are swapped you need to reconfigure the VRRP interfaces. 
+The tool crc32b is a simple version of the CRC32B.
+
+This executor takes care about the VRF of the VRRP interfaces in case if 
+main interface should be under a VRF.
+
+See *https://www.kernel.org/doc/html/latest/networking/ipvlan.html* or 
+*https://developers.redhat.com/blog/2018/10/22/introduction-to-linux-interfaces-for-virtual-networking#macvlan* or 
+*http://docs.frrouting.org/en/latest/vrrp.html* for more details.
+
+# VRRP-RELATED OPTIONS under main interface
+
+*vrrp-id* _vrrp id array_
+	List of VRRP _id_. This is used to create the virtual MACVLAN 
+	interface with a specific MAC address for each VRRP instance. 
+	This should match in the FRRouting setup.++
+*Mandadory*: _yes_
+
+*vrrp-address* _array of addresses_
+	The format should be: *VRRP_ID* _IP/MASK_ _IP/MASK_ _.._ *VRRP_ID* _IP/MASK_ _.._++
+Optionally you can assign one or more IPv4 or IPv6 to each VRRP interface.++
+But because each main interface can have multiple VRRPs, we need to specify 
+	on which VRRP pair we want the IP address. The script automatically detects 
+	the type of IP version.++
+*Mandatory*: _no_++
+*Default*: _none_
+
+# EXAMPLES using crc32b tool and FRRouting to configure the IP interfaces
+
+Configure VRRP interfaces:
+
+```
+auto eth0
+iface eth0
+	vrrp-id 10 20
+```
+
+Then you have the FRRouting config:
+
+*R01*
+```
+interface eth0
+    ip address 192.168.10.2/24
+    ip address 192.168.11.2/24
+    ipv6 address fc00::192:168:10:2/64
+    ipv6 address fc00::192:168:11:2/64
+    vrrp 10
+    vrrp 10 ip 192.168.10.1
+    vrrp 10 ipv6 fc00::192:168:10:1
+    vrrp 20
+    vrrp 20 ip 192.168.11.1
+    vrrp 20 ipv6 fc00::192:168:11:1
+!
+interface vf5b9c9a2-a-4
+    ip address 192.168.10.1/24
+!
+interface vf5b9c9a2-14-4
+    ip address 192.168.11.1/24
+!
+interface vf5b9c9a2-a-6
+    ipv6 address fc00::192:168:10:1/64
+!
+interface vf5b9c9a2-14-6
+    ipv6 address fc00::192:168:11:1/64
+```
+
+*R02*
+```
+interface eth0
+    ip address 192.168.10.3/24
+    ip address 192.168.11.3/24
+    ipv6 address fc00::192:168:10:3/64
+    ipv6 address fc00::192:168:11:3/64
+    vrrp 10
+    vrrp 10 priority 90
+    vrrp 10 ip 192.168.10.1
+    vrrp 10 ipv6 fc00::192:168:10:1
+    vrrp 20
+    vrrp 20 priority 90
+    vrrp 20 ip 192.168.11.1
+    vrrp 20 ipv6 fc00::192:168:11:1
+!
+interface vf5b9c9a2-0a-4
+    ip address 192.168.10.1/24
+!
+interface vf5b9c9a2-14-4
+    ip address 192.168.11.1/24
+!
+interface vf5b9c9a2-0a-6
+    ipv6 address fc00::192:168:10:1/64
+!
+interface vf5b9c9a2-14-6
+    ipv6 address fc00::192:168:11:1/64
+```
+
+The compute CRC32 of *eth0* with crc32b is 0xf5b9c9a2, "-0a" means 10 (0x0a) in hex and "-14" is 20 (0x14) in hex.
+
+# EXAMPLES using crc32b tool and vrrp-address option.
+```
+auto red
+iface red
+    vrf-table 300
+
+auto eth0
+iface eth0
+    address 192.168.10.2/24
+    address 192.168.11.2/24
+    address 192.168.12.2/24
+    address 192.168.13.2/24
+    address fc00:192:168:1::2/64
+    address fc00:192:168:2::2/64
+    vrf red
+    vrrp-id 10 20
+    vrrp-address 10 192.168.10.1/24 192.168.12.1/24 fc00:192:168:1::1/64 20 192.168.11.1/24 192.168.13.1/24 fc00:192:168:2::1/64
+```
+
+The configuration will be similar to:
+```
+R01:~# ip address show
+2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq master red state UP group default qlen 1000
+    link/ether 00:50:56:b5:d5:96 brd ff:ff:ff:ff:ff:ff
+    inet 192.168.10.2/24 scope global eth0
+       valid_lft forever preferred_lft forever
+    inet 192.168.11.2/24 scope global eth0
+       valid_lft forever preferred_lft forever
+    inet 192.168.12.2/24 scope global eth0
+       valid_lft forever preferred_lft forever
+    inet 192.168.13.2/24 scope global eth0
+       valid_lft forever preferred_lft forever
+    inet6 fc00:192:168:2::2/64 scope global tentative
+       valid_lft forever preferred_lft forever
+    inet6 fc00:192:168:1::2/64 scope global tentative
+       valid_lft forever preferred_lft forever
+85: vf5b9c9a2-0a-4@eth0: <BROADCAST,MULTICAST> mtu 1500 qdisc noop master red state UP group default qlen 1000
+    link/ether 00:00:5e:00:01:0a brd ff:ff:ff:ff:ff:ff protodown on
+    inet 192.168.10.1/24 scope global vf5b9c9a2-0a-4
+       valid_lft forever preferred_lft forever
+    inet 192.168.12.1/24 scope global vf5b9c9a2-0a-4
+       valid_lft forever preferred_lft forever
+86: vf5b9c9a2-0a-6@eth0: <BROADCAST,MULTICAST> mtu 1500 qdisc noop master red state UP group default qlen 1000
+    link/ether 00:00:5e:00:02:0a brd ff:ff:ff:ff:ff:ff protodown on
+    inet6 fc00:192:168:1::1/64 scope global tentative
+       valid_lft forever preferred_lft forever
+87: vf5b9c9a2-14-4@eth0: <BROADCAST,MULTICAST> mtu 1500 qdisc noop master red state UP group default qlen 1000
+    link/ether 00:00:5e:00:01:14 brd ff:ff:ff:ff:ff:ff protodown on
+    inet 192.168.11.1/24 scope global vf5b9c9a2-14-4
+       valid_lft forever preferred_lft forever
+    inet 192.168.13.1/24 scope global vf5b9c9a2-14-4
+       valid_lft forever preferred_lft forever
+88: vf5b9c9a2-14-6@eth0: <BROADCAST,MULTICAST> mtu 1500 qdisc noop master red state UP group default qlen 1000
+    link/ether 00:00:5e:00:02:14 brd ff:ff:ff:ff:ff:ff protodown on
+    inet6 fc00:192:168:2::1/64 scope global tentative
+       valid_lft forever preferred_lft forever
+```
+
+# SEE ALSO
+
+*ip-link*(8)
+
+# AUTHORS
+
+Adrian Ban <devel@easynet.dev>

--- a/doc/interfaces.scd
+++ b/doc/interfaces.scd
@@ -252,6 +252,7 @@ iface eth0
 *interfaces-ppp*(5)
 *interfaces-tunnel*(5)
 *interfaces-vrf*(5)
+*interfaces-vrrp*(5)
 *interfaces-vxlan*(5)
 *interfaces-wifi*(5)
 *interfaces-wireguard*(5)

--- a/executor-scripts/linux/vrrp
+++ b/executor-scripts/linux/vrrp
@@ -200,15 +200,18 @@ create)
 	    ${MOCK} ip link set dev ${IFACE_VRRP_4} address ${VRRP_MAC_4}
 	    # In case of boot, we must set protodown to on until FRRouting will takeover the control of the interface
 	    ${MOCK} ip link set dev ${IFACE_VRRP_4} protodown on
+	    ${MOCK} ip link set dev ${IFACE_VRRP_4} up
 	    ### Always disable IPv6 on VRRP IPv4 interface
 	    if [ -z "${MOCK}" ]; then
 		echo 1 > /proc/sys/net/ipv6/conf/${IFACE_VRRP_4}/disable_ipv6
 	    fi
 	    # Create MACVLAN interfaces for VRRP IPv6
 	    ${MOCK} ip link add link ${IFACE} name ${IFACE_VRRP_6} type macvlan mode bridge
+	    ${MOCK} ip link set dev ${IFACE_VRRP_6} addrgenmode random
 	    ${MOCK} ip link set dev ${IFACE_VRRP_6} address ${VRRP_MAC_6}
 	    # In case of OS booting, we must set protodown to on until FRRouting will takeover the control of the interface
 	    ${MOCK} ip link set dev ${IFACE_VRRP_6} protodown on
+	    ${MOCK} ip link set dev ${IFACE_VRRP_6} up
 
 	    # In case we have VRF, add VRRP interfaces under VRF
 	    if [ -n "${VRRP_VRF}" ]; then

--- a/executor-scripts/linux/vrrp
+++ b/executor-scripts/linux/vrrp
@@ -1,0 +1,345 @@
+#!/bin/sh
+# This executor is responsible for setting up the Virtual Router Redundancy Protocol (VRRP) overlay interfaces.
+#
+# Copyright (C) 2022 EasyNetDev <devel@easynet.dev>
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# This software is provided 'as is' and without any warranty, express or
+# implied. In no event shall the authors be liable for any damages arising
+# from the use of this software.
+#
+# Sun, 21 Apr 2023 10:36:31 +0300
+#  -- EasyNetDev <devel@easynet.dev>
+#
+# This executor will do the configuration for MACVLAN virtual interfaces.
+#
+# Each MACVLAN interface must be controlled by a VRRP daemon, like FRRouting.
+#
+# Options needed for VRRP executro to be able to create the MACVLAN interface are:
+#
+# IFACE                Main interface name
+# IF_VRRP_ID           VRID list to create the interfaces only
+# IF_VRRP_ADDRESS      IP list to create the interfaces and add IPs (Optional)
+#
+# Interface naming would be in format vXXXXXXXX-YY-V
+# Where
+#  ->  XXXXXXXX is CRC32 value calculated for main interface name
+#  ->  YY	is HEX value of the VRRP ID
+#  ->  V	is IP version 4 or 6
+#
+# This keeps the a fix VRRP interface name length to 14 characters (maximum are 15 characters in Linux)
+# and the part vXXXXXXXX-YY is the same for both IP protocols.
+# Also it keeps the same names after reboots if the main interface name is not changed or the CRC32 tool is not changed.
+#
+# This script is written in shell and is not using any Bash built-in functions.
+#
+
+[ -n "$VERBOSE" ] && set -x
+
+# Global variables for CRC32 tool
+crc32_cmd=""
+crc32_tool=""
+
+################################################################################
+#                        VRRP CRC32 tool functions                             #
+################################################################################
+
+# In case the crc32_tool is in auto, search for crc32b then for cksum
+find_crc32_tools_in_auto() {
+    # Search for crc32b
+    # In case we are in test mode, check for current build directory for crc32b
+    if [ -n "${MOCK}" -a -z ${crc32_cmd} ]; then
+	crc32_tool="MOCK"
+	return
+    fi
+    crc32_cmd=$(which crc32b)
+    if [ -n "${crc32_cmd}" ]; then
+	crc32_tool="crc32b"
+	return
+    fi
+    # Search for cksum
+    crc32_cmd=$(which cksum)
+    if [ -n "${crc32_cmd}" ]; then
+	crc32_tool="cksum"
+	return
+    fi
+    # If none of them are found, print an error message
+    if [ -z "${crc32_cmd}" ]; then
+	echo "Couldn't find crc32b or cksum tools! Please build ifupdown-ng with crc32b support or install coreutils package!"
+	exit 0
+    fi
+}
+
+# Compute CRC32 value using the selected CRC32 tool
+compute_crc32_hex() {
+    case "$crc32_tool" in
+	crc32b)
+	    printf "%08x" $(${crc32_cmd} $1)
+	    ;;
+	cksum)
+	    printf "%08x" $(echo $1 | ${crc32_cmd} | cut -f1 -d" ")
+	    ;;
+	MOCK)
+	    # In test mode, check if we have crc32b compiled or just return CRC32B of "eth0"
+	    if [ -x "./crc32b" ]; then
+		printf "%08x" $(./crc32b $1)
+	    else
+		echo "f5b9c9a2"
+	    fi
+	    ;;
+	*)
+	    echo "Invalid CRC32 tool: $crc32_tool! Please use crc32b or cksum!"
+	    exit 0
+	    ;;
+    esac
+}
+
+################################################################################
+#                        VRRP management functions                             #
+################################################################################
+# Check address family protocol: IPv4, IPv6, or invalid
+addr_family() {
+	if [ "$1" != "${1#*[0-9].[0-9]}" ]; then
+		echo "4"
+	elif [ "$1" != "${1#*:[0-9a-fA-F]}" ]; then
+		echo "6"
+	else
+		echo "0"
+	fi
+}
+
+# Verify the VRRP ID if has correct values: between 1 and 255
+is_vrid() {
+	if [ -z "$(echo $1 | sed 's/\([0-9]\{1,3\}\)\(.*\)/\2/g')" ]; then
+		if [ $1 -gt 0 -a $1 -le 255 ]; then
+		    return 0
+		else
+		    return 1
+		fi
+	else
+		# Could be IPv4 or IPv6 address
+		return 2
+	fi
+}
+
+# Compute the MAC address the VRRP interface
+get_vrrp_mac() {
+	VRRP_MAC_6="00:00:5e:00:02:"$(printf "%02x\n" $1)
+	VRRP_MAC_4="00:00:5e:00:01:"$(printf "%02x\n" $1)
+}
+
+
+vrrp_gen_name() {
+	# Get main interface CRC32 to generate a fix name for VRRP interface using main interface name + VRRP ID
+	IFACE_CRC32=$(compute_crc32_hex ${IFACE})
+
+	VRRP_ID_HEX=$(printf "%02x" $VRRP_ID)
+
+	IFACE_VRRP_4="v${IFACE_CRC32}-${VRRP_ID_HEX}-4"
+	IFACE_VRRP_6="v${IFACE_CRC32}-${VRRP_ID_HEX}-6"
+}
+
+init_vrrp() {
+	find_crc32_tools_in_auto
+
+	# If we don't have vrrp-id then do nothing.
+	if [ ! "$IF_VRRP_ID" ]; then
+	    exit 0
+	fi
+}
+
+case "$PHASE" in
+depend)
+	# There is no dependency because is used directly under interface.
+	exit 0
+	;;
+create)
+	init_vrrp
+	# ${MOCK} variable is used by test tools to printout the setup. We need to skip some tests if ${MOCK} is used.
+	# Check if main interface vrrp-raw-device exists in system. If not then skip.
+	if [ -z "${MOCK}" -a ! -d /sys/class/net/$IFACE ]; then
+	    echo "Main interface $IFACE doesn't exist!"
+	    exit 0
+	fi
+
+	for VRRP_ID in ${IF_VRRP_ID}; do
+
+	    if ! is_vrid $VRRP_ID; then
+		echo "VRRP ID $1 is invalid! VRRP ID must have values between 1 and 255!"
+		continue
+	    fi
+
+	    # Compute VRRP interfaces name
+	    vrrp_gen_name
+
+	    # Check if the VRRP interface itself exists. If yes then skip.
+	    if [ -z "${MOCK}" -a -d /sys/class/net/"${IFACE_VRRP_4}" ]; then
+		echo "Interface ${IFACE_VRRP_4} already exist. Please check your system."
+		continue
+	    fi
+	    if [ -z "${MOCK}" -a -d /sys/class/net/${IFACE_VRRP_6} ]; then
+		echo "Interface ${IFACE_VRRP_6} already exist. Please check your system."
+		continue
+	    fi
+
+	    VRRP_MAC_4=""
+	    VRRP_MAC_6=""
+
+	    get_vrrp_mac $VRRP_ID
+
+	    # Get the VRF for the vrrp-raw-device. VRRP interface MUST be in the same VRF as the vrrp-raw-device is.
+	    if [ -z "${MOCK}" ]; then
+		VRRP_VRF=$(ifquery -p vrf-member ${IFACE} | head -1)
+	    fi
+
+	    # Create MACVLAN interfaces for VRRP IPv4
+	    ${MOCK} ip link add link ${IFACE} name ${IFACE_VRRP_4} type macvlan mode bridge
+	    ${MOCK} ip link set dev ${IFACE_VRRP_4} address ${VRRP_MAC_4}
+	    # In case of boot, we must set protodown to on until FRRouting will takeover the control of the interface
+	    ${MOCK} ip link set dev ${IFACE_VRRP_4} protodown on
+	    ### Always disable IPv6 on VRRP IPv4 interface
+	    if [ -z "${MOCK}" ]; then
+		echo 1 > /proc/sys/net/ipv6/conf/${IFACE_VRRP_4}/disable_ipv6
+	    fi
+	    # Create MACVLAN interfaces for VRRP IPv6
+	    ${MOCK} ip link add link ${IFACE} name ${IFACE_VRRP_6} type macvlan mode bridge
+	    ${MOCK} ip link set dev ${IFACE_VRRP_6} address ${VRRP_MAC_6}
+	    # In case of OS booting, we must set protodown to on until FRRouting will takeover the control of the interface
+	    ${MOCK} ip link set dev ${IFACE_VRRP_6} protodown on
+
+	    # In case we have VRF, add VRRP interfaces under VRF
+	    if [ -n "${VRRP_VRF}" ]; then
+		${MOCK} ip link set ${IFACE_VRRP_4} master $VRRP_VRF
+		${MOCK} ip link set ${IFACE_VRRP_6} master $VRRP_VRF
+	    fi
+	done
+
+	exit 0
+	;;
+pre-up)
+	init_vrrp
+
+	# Add VRRP Virtual IPs to VRRP interfaces
+	VRRP_ID=0
+	for VRRP_IP in ${IF_VRRP_ADDRESS}; do
+	    # The format of the VRRP_ADDRESS is <VRRP_ID> <IP/MASK> <IP/MASK> .. <VRRP_ID> <IP/MASK> ..
+	    # We check if first read in the list is the VRRP_ID
+	    if [ $(addr_family ${VRRP_IP}) -eq 0 ]; then
+		# Is not an IP address, check if is VRRP_ID
+		VRRP_ID=${VRRP_IP}
+		if ! is_vrid $VRRP_ID; then
+		    echo "Unknown IP address or VRRP ID: $VRRP_ID"
+		    VRRP_ID=0
+		    continue
+		else
+		    # Compute VRRP interface to avoid unecessary CPU processing. We need only when VRRP ID changes
+		    vrrp_gen_name
+		    # Check if the VRRP interface itself exists. If yes then skip.
+		    if [ -z "${MOCK}" -a ! -d /sys/class/net/${IFACE_VRRP_4} ]; then
+			echo "Please configure main interface ${IFACE} with VRRP ID ${VRRP_ID} before adding IP addresses to VRRP interface."
+			continue
+		    fi
+		    if [ -z "${MOCK}" -a ! -d /sys/class/net/${IFACE_VRRP_6} ]; then
+			echo "Please configure main interface ${IFACE} with VRRP ID ${VRRP_ID} before adding IP addresses to VRRP interface."
+			continue
+		    fi
+		fi
+	    else
+		# This should by an IPv4 or IPv6 address
+		# Check if we have VRRP_ID in a previously step. Maybe somehow an invalid VRRP ID escape from checks
+		if ! is_vrid $VRRP_ID; then
+		    echo "Invalid VRRP ID: $VRRP_ID"
+		    VRRP_ID=0
+		    continue
+		fi
+
+		VRRP_IP_ADDR=${VRRP_IP%*/*}
+		VRRP_PREFIX=${VRRP_IP#*/*}
+
+		# Check if IP address has an netmask. If not, considering /24 or /64
+		if [ -z "$VRRP_PREFIX" ]; then
+		    if [ addr_family ${VRRP_IP_ADDR} -eq 6 ]; then
+			VRRP_NETMASK=64
+		    else
+			VRRP_NETMASK=24
+		    fi
+		fi
+
+		# Check if NETMASK if is a valid one: IPv4 between 1 to 32 and IPv6 1 to 128.
+		if [ $(addr_family ${VRRP_IP_ADDR}) -eq 6 ]; then
+		    if [ ${VRRP_PREFIX} -lt 1 -o ${VRRP_PREFIX} -gt 128 ]; then
+			echo "Invalid IPv6 prefix ($VRRP_PREFIX). Valid prefixes are between 1 and 128."
+			continue
+		    else
+			# Add IP address to the VRRP interface.
+			${MOCK} ip -6 address add ${VRRP_IP_ADDR}/${VRRP_PREFIX} dev ${IFACE_VRRP_6}
+		    fi
+		else
+		    if [ ${VRRP_PREFIX} -lt 1 -o ${VRRP_PREFIX} -gt 32 ]; then
+			echo "Invalid IPv4 prefix ($VRRP_PREFIX). Valid prefixes are between 1 and 32."
+			continue
+		    else
+			# Add IP address to the VRRP interface.
+			${MOCK} ip address add ${VRRP_IP_ADDR}/${VRRP_PREFIX} dev ${IFACE_VRRP_4}
+		    fi
+		fi
+		
+		#VRRP_ID=$(echo $VRRP_IP | cut -f1 -d",")
+		#VRRP_ADDRESSES=$(echo $VRRP_IP | cut -f2- -d"," | sed "s/,/ /g")
+
+		#VRRP_ID_HEX=$(printf "%02x" $VRRP_ID)
+		#IFACE_VRRP="v${IFACE_CRC32}-${VRRP_ID_HEX}-"
+
+		#for VRRP_ADDR in ${VRRP_ADDRESSES}; do
+		#    if [ "${VRRP_ADDR##*/*}" ] ;then
+		#	if [ addr_family $VRRP_ADDR -eq 6 ]; then
+		#	    VRRP_MASK=64
+		#	else
+		#	    VRRP_MASK=24
+		#	fi
+		#    fi
+		#done
+	    fi
+	done
+	;;
+
+post-up)
+	;;
+pre-down)
+	init_vrrp
+
+	IFACE_CRC32=$(compute_crc32_hex ${IFACE})
+
+	if [ -z "${MOCK}" -a ! -d "/sys/class/net/${IFACE}/" ]; then
+	    exit 0
+	fi
+	if [ -z "${MOCK}" ]; then
+	    VRRP_IFACES=`find /sys/class/net/${IFACE}/ -name "upper_v${IFACE_CRC32}-*" -printf "%f\n" | sed "s/upper_//g"`
+	else
+	    # Let's generate list of the interfaces for MOCK. In test mode, these interfaces doesn't exist in system.
+	    VRRP_IFACES=""
+	    for VRRP_ID in ${IF_VRRP_ID}; do
+		if ! is_vrid $VRRP_ID; then
+		    continue
+		fi
+	    # Compute VRRP interfaces name
+	    vrrp_gen_name
+	    VRRP_IFACES="$VRRP_IFACES "${IFACE_VRRP_4}" "${IFACE_VRRP_6}
+	    done
+	fi
+
+	# VRRP interfaces should be destroied in post-down, becase if you have a bond, bridge or teaming interfaces, these are destroied in "destroy" stage.
+	for VRRP_IFACE in ${VRRP_IFACES}; do
+	    if [ -z "${MOCK}" -a -d "/sys/class/net/${VRRP_IFACE}" ] || [ -n ${MOCK} ]; then
+		${MOCK} ip link del ${VRRP_IFACE} type macvlan
+	    fi
+	done
+	;;
+destroy)
+	;;
+esac
+
+exit 0

--- a/tests/linux/Kyuafile
+++ b/tests/linux/Kyuafile
@@ -15,5 +15,6 @@ atf_test_program{name='ppp_test'}
 atf_test_program{name='static_test'}
 atf_test_program{name='tunnel_test'}
 atf_test_program{name='vrf_test'}
+atf_test_program{name='vrrp_test'}
 atf_test_program{name='vxlan_test'}
 atf_test_program{name='wireguard_test'}

--- a/tests/linux/vrrp_test
+++ b/tests/linux/vrrp_test
@@ -1,0 +1,47 @@
+#!/usr/bin/env atf-sh
+
+. $(atf_get_srcdir)/../test_env.sh
+EXECUTOR="$(atf_get_srcdir)/../../executor-scripts/linux/vrrp"
+
+tests_init \
+	leader_bringup \
+	leader_teardown \
+	address_config
+
+leader_bringup_body() {
+	export MOCK=echo IFACE=eth0 PHASE=create IF_VRRP_ID="10 20" IF_VRRP_ADDRESS="10 192.168.1.1/24 fc00:192:168:1::1/64 20 192.168.2.1/24 fc00:192:168:1::1/64"
+	atf_check -s exit:0 \
+		-o match:'ip link add link eth0 name vf5b9c9a2-0a-4 type macvlan mode bridge' \
+		-o match:'ip link set dev vf5b9c9a2-0a-4 address 00:00:5e:00:01:0a' \
+		-o match:'ip link set dev vf5b9c9a2-0a-4 protodown on' \
+		-o match:'ip link add link eth0 name vf5b9c9a2-0a-6 type macvlan mode bridge' \
+		-o match:'ip link set dev vf5b9c9a2-0a-6 address 00:00:5e:00:02:0a' \
+		-o match:'ip link set dev vf5b9c9a2-0a-6 protodown on' \
+		-o match:'ip link add link eth0 name vf5b9c9a2-14-4 type macvlan mode bridge' \
+		-o match:'ip link set dev vf5b9c9a2-14-4 address 00:00:5e:00:01:14' \
+		-o match:'ip link set dev vf5b9c9a2-14-4 protodown on' \
+		-o match:'ip link add link eth0 name vf5b9c9a2-14-6 type macvlan mode bridge' \
+		-o match:'ip link set dev vf5b9c9a2-14-6 address 00:00:5e:00:02:14' \
+		-o match:'ip link set dev vf5b9c9a2-14-6 protodown on' \
+		${EXECUTOR}
+}
+
+leader_teardown_body() {
+	export MOCK=echo IFACE=eth0 PHASE=pre-down IF_VRRP_ID="10 20" IF_VRRP_ADDRESS="10 192.168.1.1/24 fc00:192:168:1::1/64 20 192.168.2.1/24 fc00:192:168:1::1/64"
+	atf_check -s exit:0 \
+		-o match:'ip link del vf5b9c9a2-0a-4 type macvlan' \
+		-o match:'ip link del vf5b9c9a2-0a-6 type macvlan' \
+		-o match:'ip link del vf5b9c9a2-14-4 type macvlan' \
+		-o match:'ip link del vf5b9c9a2-14-6 type macvlan' \
+		${EXECUTOR}
+}
+
+address_config_body() {
+	export MOCK=echo IFACE=eth0 PHASE=pre-up IF_VRRP_ID="10 20" IF_VRRP_ADDRESS="10 192.168.1.1/24 fc00:192:168:1::1/64 20 192.168.2.1/24 fc00:192:168:1::1/64"
+	atf_check -s exit:0 \
+		-o match:'ip address add 192.168.1.1/24 dev vf5b9c9a2-0a-4' \
+		-o match:'ip -6 address add fc00:192:168:1::1/64 dev vf5b9c9a2-0a-6' \
+		-o match:'ip address add 192.168.2.1/24 dev vf5b9c9a2-14-4' \
+		-o match:'ip -6 address add fc00:192:168:1::1/64 dev vf5b9c9a2-14-6' \
+		${EXECUTOR}
+}

--- a/tests/linux/vrrp_test
+++ b/tests/linux/vrrp_test
@@ -14,13 +14,18 @@ leader_bringup_body() {
 		-o match:'ip link add link eth0 name vf5b9c9a2-0a-4 type macvlan mode bridge' \
 		-o match:'ip link set dev vf5b9c9a2-0a-4 address 00:00:5e:00:01:0a' \
 		-o match:'ip link set dev vf5b9c9a2-0a-4 protodown on' \
+		-o match:'ip link set dev vf5b9c9a2-0a-4 up' \
 		-o match:'ip link add link eth0 name vf5b9c9a2-0a-6 type macvlan mode bridge' \
+		-o match:'ip link set dev vf5b9c9a2-0a-6 addrgenmode random' \
 		-o match:'ip link set dev vf5b9c9a2-0a-6 address 00:00:5e:00:02:0a' \
 		-o match:'ip link set dev vf5b9c9a2-0a-6 protodown on' \
+		-o match:'ip link set dev vf5b9c9a2-0a-6 up' \
 		-o match:'ip link add link eth0 name vf5b9c9a2-14-4 type macvlan mode bridge' \
 		-o match:'ip link set dev vf5b9c9a2-14-4 address 00:00:5e:00:01:14' \
 		-o match:'ip link set dev vf5b9c9a2-14-4 protodown on' \
+		-o match:'ip link set dev vf5b9c9a2-14-4 up' \
 		-o match:'ip link add link eth0 name vf5b9c9a2-14-6 type macvlan mode bridge' \
+		-o match:'ip link set dev vf5b9c9a2-14-6 addrgenmode random' \
 		-o match:'ip link set dev vf5b9c9a2-14-6 address 00:00:5e:00:02:14' \
 		-o match:'ip link set dev vf5b9c9a2-14-6 protodown on' \
 		${EXECUTOR}

--- a/tools/crc32b.c
+++ b/tools/crc32b.c
@@ -1,0 +1,51 @@
+/*
+ * cmd/crc32b.c
+ * Purpose: Implement simple CRC32B checksum to be used in VRRP executor.
+ *
+ * This software is provided 'as is' and without any warranty, express or
+ * implied.  In no event shall the authors be liable for any damages arising
+ * from the use of this software.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+static uint32_t crc32b(uint8_t *message) {
+   int i, j;
+   unsigned int byte, crc, mask;
+
+   i = 0;
+   crc = 0xFFFFFFFF;
+   while (message[i] != 0) {
+      byte = message[i];            // Get next byte.
+      crc = crc ^ byte;
+      for (j = 7; j >= 0; j--) {    // Do eight times.
+         mask = -(crc & 1);
+         crc = (crc >> 1) ^ (0xEDB88320 & mask);
+      }
+      i = i + 1;
+   }
+   return ~crc;
+}
+
+static void help(void)
+{
+    printf("\n");
+    printf("Usage: crc32b <STRING>\n");
+    printf("Returns computed CRC32B of the input string.\n");
+    printf("\n");
+}
+
+int main(int32_t argc, char **argv)
+{
+    if (argc <= 1) {
+	printf("Argument must contain at least one character.\n");
+	help();
+	exit(EXIT_FAILURE);
+    }
+
+    //printf("0x%08x\n", crc32b((uint8_t *)argv[1]));
+    printf("%u\n", crc32b((uint8_t *)argv[1]));
+    exit(EXIT_SUCCESS);
+}


### PR DESCRIPTION
Hi,

This is my proposal for VRRP executor for ifupdown-ng.
I will close the old one #206.

Main features:
1. Automatically creates VRRP interfaces for requested VRRP IDs.
2. Build-in CRC32B tool under tools to be used on systems that doesn't have cksum tool. This is a simple CRC32B tool.
3. The VRRP interfaces are preserved between reboots if is using the same CRC32 tool.
4. VRRP interfaces are in format vXXXXXXXX-YY-V, where XXXXXXXX is the hex vablue of CRC32 computed from main interface name, YY is the hex value of VRRP ID (from 0x01 to 0xff) and V is the IP protocol number: 4 or 6.
5. VRRP needs 2 interfaces each one with different MAC address in format: 00:00:5e:00:0A:BB, where A should be 1 for IPv4 and 2  for IPv6, BB is hex value of VRRP ID.
6. Can add VRRP IPs from configuration or it can be used without this option and use FRRouting to add these IPs.
7. By default the MACVLAN interfaces are activated with `protodown on` to avoid duplicate IP in network between the moment the interfaces are created and FRRouting is booting.
8. Added tests for executor.

Please review my patch and let's try to submit. I'm already running a version of ifupdown-ng using VRRP and Teaming patches for more than 2 weeks on multiple routers / test PCs.
