### PR TITLE
Support consistent options for all DHCP implementations (where possible)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,6 +170,7 @@ MANPAGES_5 = \
 	doc/interfaces-batman.5 \
 	doc/interfaces-bridge.5 \
 	doc/interfaces-forward.5 \
+	doc/interfaces-dhcp.5 \
 	doc/interfaces-ppp.5 \
 	doc/interfaces-tunnel.5 \
 	doc/interfaces-vrf.5 \

--- a/doc/interfaces-dhcp.scd
+++ b/doc/interfaces-dhcp.scd
@@ -1,0 +1,71 @@
+interfaces-wireguard(5)
+
+# NAME
+
+*interfaces-dhcp* - DHCP extensions for the interfaces(5) file format
+
+# DESCRIPTION
+
+DHCP configure is provided by one of the following clients, in order 
+of preference: dhcpcd, dhclient, and udhcpc
+
+No explict module configuration is required, but several options are available:
+
+# DHCP-RELATED OPTIONS
+
+*dhcp-hostname* _name_
+	Specified a hostname to be sent as part of DHCP queries. If
+	not provided this value is guessed by ifupdown.
+	This option is not supported for dhclient
+
+*dhcp-vendor* _vendor_class_
+	Specifies a vendor class to be sent as part of DHCP queries.
+	This option is not supported for dhclient
+
+*dhcp-client_id* _client_id_
+	Specifies a client ID to be sent as part of DHCP queries.
+	This option is not supported for dhclient
+
+*dhcp-leasetime* _seconds_
+	Requests a specific lease interval from the DHCP server.
+	This option is not supported for dhclient
+
+*dhcp-config* _path_
+	Provide the specified config file to the DHCP client. This
+	can be used to provide additional client configuration not
+	available via these parameters.
+	This option is not supported for udhcpc
+
+*dhcp-script* _path_
+	Specifies the script file called after DHCP events.
+
+*dhcp-opts* _str_
+	Additional arugments passed unmodified to the DHCP client.
+	Use this to pass additional options otherwise not supported
+	by this executor. For compatibility udhcpc also accepts this
+	options when named: udhcpc_opts
+
+# EXAMPLES
+
+Typical (minimal) configuration
+
+```
+auto foo
+iface foo
+	use dhcp
+```
+
+All avialable options for a host using dhcpcd
+
+```
+auto foo
+iface foo
+	use dhcp
+	dhcp-hostname bar
+	dhcp-vendor MyVendor
+	dhcp-client_id 0100BEEFC0FFEE
+	dhcp-leasetime 86400
+	dhcp-script /usr/lib/dhcpcd/dhcpcd-run-hooks
+	dhcp-config /etc/dhcpcd-$IFACE.conf
+	dhcp-opts --nogateway
+```

--- a/doc/interfaces-dhcp.scd
+++ b/doc/interfaces-dhcp.scd
@@ -1,4 +1,4 @@
-interfaces-wireguard(5)
+interfaces-dhcp(5)
 
 # NAME
 
@@ -6,10 +6,11 @@ interfaces-wireguard(5)
 
 # DESCRIPTION
 
-DHCP configure is provided by one of the following clients, in order 
-of preference: dhcpcd, dhclient, and udhcpc
+DHCP configuration is provided by one of the following clients, in
+this order of preference: dhcpcd, dhclient, and udhcpc
 
-No explict module configuration is required, but several options are available:
+No explict module configuration is required, but several options are
+available:
 
 # DHCP-RELATED OPTIONS
 
@@ -43,7 +44,7 @@ No explict module configuration is required, but several options are available:
 	Additional arugments passed unmodified to the DHCP client.
 	Use this to pass additional options otherwise not supported
 	by this executor. For compatibility udhcpc also accepts this
-	options when named: udhcpc_opts
+	option when named: udhcpc-opts
 
 # EXAMPLES
 
@@ -55,7 +56,7 @@ iface foo
 	use dhcp
 ```
 
-All avialable options for a host using dhcpcd
+All available options for a host using dhcpcd
 
 ```
 auto foo

--- a/executor-scripts/linux/dhcp
+++ b/executor-scripts/linux/dhcp
@@ -14,24 +14,27 @@ determine_implementation() {
 start() {
 	case "$1" in
 	dhcpcd)
+		optargs=$(eval echo $IF_DHCP_OPTS)
 		[ -n "$IF_DHCP_HOSTNAME" ] && optargs="$optargs -h $IF_DHCP_HOSTNAME"
 		[ -n "$IF_DHCP_VENDOR" ] && optargs="$optargs -i $IF_DHCP_VENDOR"
-		[ -n "$IF_DHCP_CLIENT_ID" ] && optargs="$optargs -i $IF_DHCP_CLIENT_ID"
+		[ -n "$IF_DHCP_CLIENT_ID" ] && optargs="$optargs -I $IF_DHCP_CLIENT_ID"
 		[ -n "$IF_DHCP_LEASETIME" ] && optargs="$optargs -l $IF_DHCP_LEASETIME"
+		[ -n "$IF_DHCP_CONFIG" ] && optargs="$optargs -f $IF_DHCP_CONFIG"
+		[ -n "$IF_DHCP_SCRIPT" ] && optargs="$optargs -c $IF_DHCP_SCRIPT"
 		${MOCK} /sbin/dhcpcd $optargs $IFACE
 		;;
 	dhclient)
-		# Specific config file given?
-		if [ -n "$IF_DHCP_CONFIG" ]; then
-			optargs="$optargs -cf $IF_DHCP_CONFIG"
-		fi
-
+		optargs=$(eval echo $IF_DHCP_OPTS)
+		[ -n "$IF_DHCP_CONFIG" ] && optargs="$optargs -cf $IF_DHCP_CONFIG"
+		[ -n "$IF_DHCP_SCRIPT" ] && optargs="$optargs -sf $IF_DHCP_SCRIPT"
 		${MOCK} /usr/sbin/dhclient -pf /var/run/dhclient.$IFACE.pid $optargs $IFACE
 		;;
 	udhcpc)
-		optargs=$(eval echo $IF_UDHCPC_OPTS)
-		[ -n "$IF_DHCP_HOSTNAME" ] && optargs="$optargs -x hostname:$IF_DHCP_HOSTNAME"
-		[ -n "$IF_DHCP_CLIENT_ID" ] && optargs="$optargs -c $IF_DHCP_CLIENT_ID"
+		optargs=$(eval echo $IF_UDHCPC_OPTS $IF_DHCP_OPTS)
+		[ -n "$IF_DHCP_HOSTNAME" ] && optargs="$optargs -x hostname:${IF_DHCP_HOSTNAME}"
+		[ -n "$IF_DHCP_VENDOR" ] && optargs="$optargs -V $IF_DHCP_VENDOR"
+		[ -n "$IF_DHCP_CLIENT_ID" ] && optargs="$optargs -x 0x3d:${IF_DHCP_CLIENT_ID}"
+		[ -n "$IF_DHCP_LEASETIME" ] && optargs="$optargs -x lease:${IF_DHCP_LEASETIME}"
 		[ -n "$IF_DHCP_SCRIPT" ] && optargs="$optargs -s $IF_DHCP_SCRIPT"
 		${MOCK} /sbin/udhcpc -b -R -p /var/run/udhcpc.$IFACE.pid -i $IFACE $optargs
 		;;

--- a/tests/linux/dhcp_test
+++ b/tests/linux/dhcp_test
@@ -9,7 +9,14 @@ tests_init udhcpc_up \
 	dhclient_up \
 	udhcpc_opts_up \
 	udhcpc_opts_up_subshell \
-	hostname_subshell
+	hostname_subshell \
+	dhcp_opts \
+	dhcp_opts_subshell \
+	vendor \
+	clientid \
+	config \
+	script \
+	leasetime
 
 udhcpc_up_body() {
 	export IFACE=eth0 PHASE=up MOCK=echo IF_DHCP_PROGRAM=udhcpc
@@ -50,5 +57,89 @@ udhcpc_opts_up_subshell_body() {
 hostname_subshell_body() {
 	export IFACE=eth0 PHASE=up MOCK=echo IF_DHCP_PROGRAM=udhcpc IF_DHCP_HOSTNAME="\$(echo test)"
 	atf_check -s exit:0 -o match:'/sbin/udhcpc -b -R -p /var/run/udhcpc.eth0.pid -i eth0 -x hostname:test' \
+		${EXECUTOR}
+}
+
+dhcp_opts_body() {
+	export IFACE=eth0 PHASE=up MOCK=echo IF_DHCP_PROGRAM=dhcpcd IF_DHCP_OPTS="--no-gateway"
+	atf_check -s exit:0 -o match:'/sbin/dhcpcd --no-gateway eth0' \
+		${EXECUTOR}
+	export IF_DHCP_PROGRAM=dhclient IF_DHCP_OPTS="-s 255.255.255.255"
+	atf_check -s exit:0 -o match:'/usr/sbin/dhclient -pf /var/run/dhclient.eth0.pid -s 255.255.255.255 eth0' \
+		${EXECUTOR}
+	export IF_DHCP_PROGRAM=udhcpc IF_DHCP_OPTS="-O search"
+	atf_check -s exit:0 -o match:'/sbin/udhcpc -b -R -p /var/run/udhcpc.eth0.pid -i eth0 -O search' \
+		${EXECUTOR}
+}
+
+dhcp_opts_subshell_body() {
+	export IFACE=eth0 PHASE=up MOCK=echo IF_DHCP_PROGRAM=dhcpcd IF_DHCP_OPTS="--no-\$(echo gateway)"
+	atf_check -s exit:0 -o match:'/sbin/dhcpcd --no-gateway eth0' \
+		${EXECUTOR}
+	export IF_DHCP_PROGRAM=dhclient IF_DHCP_OPTS="-s \$(echo 255.255.255.255)"
+	atf_check -s exit:0 -o match:'/usr/sbin/dhclient -pf /var/run/dhclient.eth0.pid -s 255.255.255.255 eth0' \
+		${EXECUTOR}
+	export IF_DHCP_PROGRAM=udhcpc IF_DHCP_OPTS="-O \$(echo search)"
+	atf_check -s exit:0 -o match:'/sbin/udhcpc -b -R -p /var/run/udhcpc.eth0.pid -i eth0 -O search' \
+		${EXECUTOR}
+}
+
+vendor_body() {
+	export IFACE=eth0 PHASE=up MOCK=echo IF_DHCP_PROGRAM=dhcpcd IF_DHCP_VENDOR=VendorFoo
+	atf_check -s exit:0 -o match:'/sbin/dhcpcd -i VendorFoo eth0' \
+		${EXECUTOR}
+	export IF_DHCP_PROGRAM=dhclient # Not supported
+	atf_check -s exit:0 -o match:'/usr/sbin/dhclient -pf /var/run/dhclient.eth0.pid eth0' \
+		${EXECUTOR}
+	export IF_DHCP_PROGRAM=udhcpc
+	atf_check -s exit:0 -o match:'/sbin/udhcpc -b -R -p /var/run/udhcpc.eth0.pid -i eth0 -V VendorFoo' \
+		${EXECUTOR}
+}
+
+clientid_body() {
+	export IFACE=eth0 PHASE=up MOCK=echo IF_DHCP_PROGRAM=dhcpcd IF_DHCP_CLIENT_ID=0100BEEFC0FFEE
+	atf_check -s exit:0 -o match:'/sbin/dhcpcd -I 0100BEEFC0FFEE eth0' \
+		${EXECUTOR}
+	export IF_DHCP_PROGRAM=dhclient # Not supported
+	atf_check -s exit:0 -o match:'/usr/sbin/dhclient -pf /var/run/dhclient.eth0.pid eth0' \
+		${EXECUTOR}
+	export IF_DHCP_PROGRAM=udhcpc
+	atf_check -s exit:0 -o match:'/sbin/udhcpc -b -R -p /var/run/udhcpc.eth0.pid -i eth0 -x 0x3d:0100BEEFC0FFEE' \
+		${EXECUTOR}
+}
+
+config_body() {
+	export IFACE=eth0 PHASE=up MOCK=echo IF_DHCP_PROGRAM=dhcpcd IF_DHCP_CONFIG=/etc/conf
+	atf_check -s exit:0 -o match:'/sbin/dhcpcd -f /etc/conf eth0' \
+		${EXECUTOR}
+	export IF_DHCP_PROGRAM=dhclient
+	atf_check -s exit:0 -o match:'/usr/sbin/dhclient -pf /var/run/dhclient.eth0.pid -cf /etc/conf eth0' \
+		${EXECUTOR}
+	export IF_DHCP_PROGRAM=udhcpc # Not supported
+	atf_check -s exit:0 -o match:'/sbin/udhcpc -b -R -p /var/run/udhcpc.eth0.pid -i eth0' \
+		${EXECUTOR}
+}
+
+script_body() {
+	export IFACE=eth0 PHASE=up MOCK=echo IF_DHCP_PROGRAM=dhcpcd IF_DHCP_SCRIPT=/usr/libexec/dhcp
+	atf_check -s exit:0 -o match:'/sbin/dhcpcd -c /usr/libexec/dhcp eth0' \
+		${EXECUTOR}
+	export IF_DHCP_PROGRAM=dhclient
+	atf_check -s exit:0 -o match:'/usr/sbin/dhclient -pf /var/run/dhclient.eth0.pid -sf /usr/libexec/dhcp eth0' \
+		${EXECUTOR}
+	export IF_DHCP_PROGRAM=udhcpc
+	atf_check -s exit:0 -o match:'/sbin/udhcpc -b -R -p /var/run/udhcpc.eth0.pid -i eth0 -s /usr/libexec/dhcp' \
+		${EXECUTOR}
+}
+
+leasetime_body() {
+	export IFACE=eth0 PHASE=up MOCK=echo IF_DHCP_PROGRAM=dhcpcd IF_DHCP_LEASETIME=12345
+	atf_check -s exit:0 -o match:'/sbin/dhcpcd -l 12345 eth0' \
+		${EXECUTOR}
+	export IF_DHCP_PROGRAM=dhclient # Not supported
+	atf_check -s exit:0 -o match:'/usr/sbin/dhclient -pf /var/run/dhclient.eth0.pid eth0' \
+		${EXECUTOR}
+	export IF_DHCP_PROGRAM=udhcpc
+	atf_check -s exit:0 -o match:'/sbin/udhcpc -b -R -p /var/run/udhcpc.eth0.pid -i eth0 -x lease:12345' \
 		${EXECUTOR}
 }


### PR DESCRIPTION
All DHCP clients now support:
	dhcp-opts STRING
	dhcp-script PATH

dhcpcd and dhclient (but not udhcpc) now support:
	dhcp-config PATH

dhcpcd and udhcpc (but not dhclient) now support:
	dhcp-hostname STRING
	dhcp-client_id HEX
	dhcp-vendor STRING
	dhcp-leasetime INT

Add related document in interfaces-dhcp

Extend tests to include MOCK evaluation of these updated options for all 3 clients

--

Resolves a bug where dhcpcd uses the -i flag for both client_id and vendor; client_id now uses -I

Improves busybox compatiblity for udhcpc by using -x 0x3d instead of -c for client_id

Resolves ifupdown-ng issue #177