### PR TITLE
Fix link executor test in case there is an interface named "servers" on machine

### DIFF
--- a/executor-scripts/linux/link
+++ b/executor-scripts/linux/link
@@ -42,13 +42,15 @@ create)
 			${MOCK} modprobe dummy
 		fi
 
-		if [ -d "/sys/class/net/${IFACE}" ]; then
-			if [ ! -d "/sys/devices/virtual/net/${IFACE}" ]; then
-				echo "Interface ${IFACE} exists but is not a virtual interface"
-				exit 1
-			fi
+		if [ -z "${MOCK}" ]; then
+			if [ -d "/sys/class/net/${IFACE}" ]; then
+				if [ ! -d "/sys/devices/virtual/net/${IFACE}" ]; then
+					echo "Interface ${IFACE} exists but is not a virtual interface"
+					exit 1
+				fi
 
-			exit 0
+				exit 0
+			fi
 		fi
 
 		${MOCK} ip link add "${IFACE}" type dummy
@@ -64,11 +66,11 @@ create)
 		fi
 
 	elif is_vlan; then
-		if [ -d "/sys/class/net/${IFACE}" ]; then
-			exit 0
-		fi
 
 		if [ -z "${MOCK}" ]; then
+			if [ -d "/sys/class/net/${IFACE}" ]; then
+			    exit 0
+			fi
 			if [ ! -d "/sys/class/net/${IF_VLAN_RAW_DEVICE}" ]; then
 				echo "Underlay device ${IF_VLAN_RAW_DEVICE} for ${IFACE} does not exist"
 				exit 1


### PR DESCRIPTION
Fix link executor for tests in case on compilation machine interface in case an interface with name "servers" exist

In case is in test mode, MOCK variable is set then we should skip interface presence check in system.

On my test machine I had a VRF named "servers" and is the same name for the VLAN 123 test in vlan_explicit_create.