### PR TITLE
Add VXLAN EVPN parameters for FRRouting

### DIFF
--- a/doc/interfaces-vxlan.scd
+++ b/doc/interfaces-vxlan.scd
@@ -71,6 +71,15 @@ other options are optional.
 	Specifies the UDP destination port of the remote VXLAN tunnel endpoint.
 	The default is 4789.
 
+*vxlan-evpn* _bool_
+	Instruct bridge to set specific EVPN VXLAN parameters for this interface.
+	This is esencial essential for FRRouting to be able to manage the BGP EVPN.
+	_bool_ can be given as _yes_/_no_ or _0_/_1_. Default is _no_.
+	When this parameter is _yes_, bridge will automatically set these parameters to VXLAN
+	interface: addrgenmode none of interface, neigh_suppress on learning off on VXLAN
+	interface as type bridge_slave.
+	More about EVPN VXLAN here: https://docs.frrouting.org/en/latest/evpn.html
+
 # EXAMPLES
 
 A VTEP with multiple peers addressed via a multicast group:

--- a/executor-scripts/linux/bridge
+++ b/executor-scripts/linux/bridge
@@ -59,6 +59,12 @@ add_ports() {
 			ip link set dev $port addr $IF_BRIDGE_HW
 		fi
 		ip link set dev $port master $IFACE && ip link set dev $port up
+		## Specific VXLAN under the bridge. More about this here: https://docs.frrouting.org/en/latest/evpn.html
+		if [ "$(port_is_vxlan_evpn ${port})" = 1 ]; then
+			# Disable IPv6 autoconfiguration. We are a port under a bridge.
+			ip link set dev $port addrgenmode none
+			ip link set dev $port type bridge_slave neigh_suppress on learning off
+		fi
 	done
 }
 
@@ -126,6 +132,9 @@ set_bridge_opts() {
 	[ -x /sbin/brctl ] && set_bridge_opts_brctl && return 0
 }
 
+port_is_vxlan_evpn() {
+	echo yesno "$(ifquery -p vxlan-evpn "${1}" 2>/dev/null || true)"
+}
 
 all_ports_ready() {
 	local port=


### PR DESCRIPTION
ifupdown-ng is missing some parameters for VXLAN when is part of a bridge. FRRouting recomands these: https://docs.frrouting.org/en/latest/evpn.html#linux-interface-configuration

Linux Interface Configuration

The Linux kernel offers several options for configuring netdevices for an EVPN-VXLAN environment. The following section will include samples of a few netdev configurations that are compatible with FRR which implement the environment described above.

Some high-level config considerations:

- The local VTEP-IP should always be set to a reachable IP on the lo device.
- An L3VNI should always have an SVI (aka the L3-SVI).
- An L3-SVI should not be assigned an IP address, link-local or otherwise.
  - IPv6 address autoconfiguration can be disabled via addrgenmode none.
- An SVI for an L2VNI is only needed for routing (IRB) or ARP/ND suppression.
  - ARP/ND suppression is a kernel function, it is not managed by FRR.
  - ARP/ND suppression is enabled per bridge_slave via neigh_suppress.
  - ARP/ND suppression should only be enabled on vxlan interfaces.
  - IPv4/IPv6 forwarding should be disabled on SVIs not used for routing (IRB).
- Dynamic MAC/VTEP learning should be disabled on VXLAN interfaces used in EVPN.
  - Dynamic MAC learning is a function of the kernel bridge driver, not FRR.
  - Dynamic MAC learning is toggled per bridge_slave via learning {on|off}.
  - Dynamic VTEP learning is a function of the kernel vxlan driver, not FRR.
  - Dynamic VTEP learning is toggled per vxlan interface via [no]learning.
- The VXLAN interfaces should not have a remote VTEP defined.
  - Remote VTEPs are learned via EVPN, so static VTEPs are unnecessary.

ifupdown-ng offers only `vxlan-learning on/off`.

I've added a new option named `vxlan-evpn yes/no` which will indicates to bridge executor to apply necessary parameters to VXLAN interface.
