### PR TITLE
executors: Implement basic network namespace features

### DIFF
--- a/executor-scripts/linux/link
+++ b/executor-scripts/linux/link
@@ -66,6 +66,16 @@ create)
 		fi
 
 		${MOCK} ip link add link "$IF_VLAN_RAW_DEVICE" name "$IFACE" type vlan id "$IF_VLAN_ID"
+
+	# Only fetch physical devices from the configured network namespace
+	elif [ -n "$IF_NETNS" ] && ${MOCK} ip netns exec "$IF_NETNS" [ -d /sys/class/net/"$IFACE"/device ]; then
+		# NOTE: Negate test to treat wired interfaces as the default case during tests
+		if ! phy=$(${MOCK} ip netns exec "$IF_NETNS" cat /sys/class/net/"$IFACE"/phy80211/name 2> /dev/null); then
+			${MOCK} ip -n "$IF_NETNS" link set "$IFACE" netns $$
+		else
+			${MOCK} ip netns exec "$IF_NETNS" "$(command -v iw)" phy "$phy" set netns $$
+		fi
+
 	fi
 	;;
 up)
@@ -91,6 +101,15 @@ destroy)
 
 	if [ "$IF_LINK_TYPE" = 'dummy' ] || [ "$IF_LINK_TYPE" = 'veth' ] || is_vlan; then
 		${MOCK} ip link del "$IFACE"
+
+	# Only send physical devices to the configured network namespace
+	elif [ -n "$IF_NETNS" ] && [ -d /sys/class/net/"$IFACE"/device ]; then
+		# NOTE: Negate test to treat wired interfaces as the default case during tests
+		if ! phy=$(${MOCK} cat /sys/class/net/"$IFACE"/phy80211/name 2> /dev/null); then
+			${MOCK} ip link set "$IFACE" netns "$IF_NETNS"
+		else
+			${MOCK} iw phy "$phy" set netns name "$IF_NETNS"
+		fi
 	fi
 	;;
 esac

--- a/executor-scripts/linux/wireguard
+++ b/executor-scripts/linux/wireguard
@@ -1,15 +1,15 @@
 #!/bin/sh
 [ -n "$VERBOSE" ] && set -x
-[ -z "$IF_WIREGUARD_CONFIG_PATH" ] && IF_WIREGUARD_CONFIG_PATH="/etc/wireguard/$IFACE.conf"
 
 case "$PHASE" in
 create)
-	${MOCK} ip link add $IFACE type wireguard
+	${MOCK} ip link add "$IFACE" type wireguard
 	;;
 pre-up)
-	${MOCK} wg setconf $IFACE $IF_WIREGUARD_CONFIG_PATH
+	: "${IF_WIREGUARD_CONFIG_PATH:=/etc/wireguard/"$IFACE".conf}"
+	${MOCK} wg setconf "$IFACE" "$IF_WIREGUARD_CONFIG_PATH"
 	;;
 destroy)
-	${MOCK} ip link delete dev $IFACE
+	${MOCK} ip link delete dev "$IFACE"
 	;;
 esac

--- a/executor-scripts/linux/wireguard
+++ b/executor-scripts/linux/wireguard
@@ -7,6 +7,8 @@ create)
 	;;
 pre-up)
 	: "${IF_WIREGUARD_CONFIG_PATH:=/etc/wireguard/"$IFACE".conf}"
+
+	${MOCK} export WG_ENDPOINT_RESOLUTION_RETRIES="${IF_WG_ENDPOINT_RESOLUTION_RETRIES:-15}"
 	${MOCK} wg setconf "$IFACE" "$IF_WIREGUARD_CONFIG_PATH"
 	;;
 destroy)

--- a/executor-scripts/linux/wireguard
+++ b/executor-scripts/linux/wireguard
@@ -3,7 +3,13 @@
 
 case "$PHASE" in
 create)
-	${MOCK} ip link add "$IFACE" type wireguard
+	if [ -n "$IF_NETNS" ]; then
+		# Create interface in the configured network namespace
+		${MOCK} ip -n "$IF_NETNS" link add "$IFACE" type wireguard
+		${MOCK} ip -n "$IF_NETNS" link set "$IFACE" netns $$
+	else
+		${MOCK} ip link add "$IFACE" type wireguard
+	fi
 	;;
 pre-up)
 	: "${IF_WIREGUARD_CONFIG_PATH:=/etc/wireguard/"$IFACE".conf}"

--- a/executor-scripts/linux/wireguard-quick
+++ b/executor-scripts/linux/wireguard-quick
@@ -3,6 +3,7 @@
 
 case "$PHASE" in
 create)
+	${MOCK} export WG_ENDPOINT_RESOLUTION_RETRIES="${IF_WG_ENDPOINT_RESOLUTION_RETRIES:-15}"
 	${MOCK} wg-quick up $IFACE
 	;;
 destroy)


### PR DESCRIPTION
Introduce a new variable / keyword, `netns [NAME / PID]`
It defines a network namespace, where a _physical_ interface should be fetched from and send to, during the `create` and `destroy` phases 

This does not implement network namespace creation nor management

As an example use case, this PR also adds netns awareness to the wireguard executor
This allows creating a setup following the [The New Namespace Solution](https://www.wireguard.com/netns/#the-new-namespace-solution) using (monstly) ifupdown-ng configuration files


<details>
<summary>My current setup (trimmed), that works on Alpine Linux 3.19:</summary>

`/etc/inittab`:
```
# Somewhere up here the default runlevel is started
...                                                                                   
# Name the init network namespace for convenience
::wait:/sbin/ip netns attach init 1
::wait:/sbin/ip netns set init auto
# Network namespace that routes all traffic through a VPN
::wait:/sbin/ip netns add vpn
::once:/sbin/ip netns exec vpn /sbin/openrc vpn
...
```
- As this implementation doesn't actually manage the network namespaces, they're created here
- The `vpn` runlevel holds all services that should live within that netns
  I use this machine as a router, so that'd be `sshd`, `hostapd`, `dnsmasq`, `nftables`, etc.

`/etc/netns/vpn/network/interfaces`:
```
# Loopback interface - Configured for the VPN netns                                                                                  
auto lo
iface lo
    forward-ipv4 yes

# Internal Ethernet interface - facing LAN
auto eth0
iface eth0
    netns init

    forward-ipv4 yes

    address 192.168.1.1/24

# Internal WiFi interface - facing LAN
auto wlan0
iface wlan0
    netns init
    
    forward-ipv4 yes

    address 192.168.2.1/24

# External interface - Tunnel connected to init netns, facing WAN                                                                    
auto wg0
iface wg0
    use wireguard
    netns init
    wg-endpoint-resolution-retries 5
    
    forward-ipv4 yes
    
    address !supplied by VPN provider!
    gateway !supplied by VPN provider!
```
- This takes advantage of the mountspace masking `ip netns exec` does, to allow multiple `interfaces` files for different namespaces
- Of course you'd have to configure the init namespace to be able to connect to the internet / VPN provider
- I also have a netns specific `resolve.conf` and `nftables.nft`, taking advantage of that same masking, but that's out of scope for this example
</details>

<details>
<summary>My (barely edited) thoughts about this implementation and broader netns support</summary>

this currently depends on iproute2 (and iw) to be available, as busybox ip hasn't implemented the functionality needed

this can be made to work without iproute2, using only busybox ip, if desired
that would introduce dependency on nsenter and unbound commands
wlan will always require iw

about netns management / creation in the config
netns variable in loopback special meaning
unambiguous, as there can ever only be one lo per netns
new toplevel netns keyword, like iface
both cases assumption is that following configuration applies to / happens inside defined netns until a new one is defined
new keyword would make more sense, so `ifdown -n netns` or something makes more sense, and the program can safely assume that it should try to down all interfaces, and delete the netns

still netns variable inside iface config meaningful, as the devices can be in other netns than PID 1, so adding a way to define where to fetch them is useful

netns creation can easily be implemented shellscript only
netns management and deletion not really
iface creation in the correct netns would be cumbersome shellscript only, as that would mean making all the script aware of variable, but is not undoable
i considered using an alias / a wrapper to replace `ip` with `ip -n $IF_NETNS`, but if the scripts need to check something in `/sys/class/net` that'd break

a more general implementation, where even virtual interface fetching / sending is handled by link is not possible at 'create' phase, as link executor always runs before any specialised executors
its not possible because i want to use the same variable for wireguard
if wireguard executor gets, IF_WIREGUARD_HOME_NETNS or something, netns handling in link can apply to all interfaces
that might be preferable if wireguard truly is the only interface type to care about such a thing
it'd get rid of the kind of expensive device check
i dont think there's any real world use for it

it could be possible to also just configure and up the wg device in the home netns before running configs in the new netns, where the wg would be moved to
but that would mean running all phases from create to up just to have the device available
you could also move the interface movement to a later phase, like pre-up, so the wireguard create phase runs first, but that feels hacky just for this one specific case
<details>