### PR TITLE
bridge executor: allow 'bridge-stp on' with iproute2

### DIFF
--- a/executor-scripts/linux/bridge
+++ b/executor-scripts/linux/bridge
@@ -91,7 +91,7 @@ set_bridge_opts_brctl() {
 
 yesno() {
 	case "$1" in
-	yes|YES|true|TRUE|1)
+	on|ON|yes|YES|true|TRUE|1)
 		echo 1
 		;;
 	*)


### PR DESCRIPTION
Enabling bridge-stp according to the documentation doesn't work when iproute2 is used. The yesno function only detects the boolean types which don't include 'on'/'off' as used by brctl.

Add on & ON to the valid values for boolean types.