### PR TITLE
Fix an error when stopping interfaces with cake configured but not active

### DIFF
--- a/executor-scripts/linux/cake
+++ b/executor-scripts/linux/cake
@@ -57,6 +57,9 @@ down)
 	if [ -z "${MOCK}" -a ! -d "/sys/class/net/${IFACE}" ]; then
 		exit 0
 	fi
+	if ! tc qdisc show dev "$IFACE" 2>/dev/null | grep -q cake; then
+		exit 0
+	fi
 	${MOCK} tc qdisc del root dev "$IFACE"
 	;;
 esac


### PR DESCRIPTION
Do not attempt to delete the qdisc if cake is not active on the interface

This avoids a spurious error (and ifdown status failure) when stopping interfaces that exist and are configured with cake but which do not have an active cake qdisc when ifdown is run. This can happen when the interface exists but has not been fully configured when stopped, or if a cake configuration is added after the interface is brought up, or if the qdisc is removed via some means other than ifdown