### PR TITLE
wifi: pass psk as argument to wpa_passphrase

### DIFF
--- a/executor-scripts/linux/wifi
+++ b/executor-scripts/linux/wifi
@@ -14,7 +14,7 @@
 # Vocabulary:
 #   wifi-ssid - The SSID name to connect to.
 #   wifi-psk - The pre-shared key to use.
-#   wifi-config - A path to a wpa_supplicant config file, for special configs.
+#   wifi-config-path - A path to a wpa_supplicant config file, for special configs.
 #
 # If wifi-config is not set, wifi-ssid and wifi-psk are required, and a config
 # will be generated as /run/wpa_supplicant.$IFACE.conf.
@@ -46,8 +46,7 @@ generate_config() {
 	[ -z "$IF_WIFI_SSID" ] && die "wifi-ssid not set"
 	[ -z "$IF_WIFI_PSK" ] && die "wifi-psk not set"
 
-	# We use a pipeline here to avoid leaking PSK into the process name.
-	(echo "$IF_WIFI_PSK" | /sbin/wpa_passphrase "$IF_WIFI_SSID") >$WIFI_CONFIG_PATH
+	/sbin/wpa_passphrase "$IF_WIFI_SSID" "$IF_WIFI_PSK" >$WIFI_CONFIG_PATH
 
 	[ ! -e "$WIFI_CONFIG_PATH" ] && die "failed to write temporary config: $WIFI_CONFIG_PATH"
 }


### PR DESCRIPTION
wpa_supplicant-2.11 changed wpa_passphrase to require a tty.

The only problem i see is that password may now show in audit logs, if that's a problem we can generate config manually with heredoc i guess.