### PR TITLE
bridge executor: change implementation of 'bridge-hw'

### DIFF
--- a/executor-scripts/linux/bridge
+++ b/executor-scripts/linux/bridge
@@ -55,9 +55,6 @@ all_ports() {
 add_ports() {
 	local port=
 	for port in $PORTS; do
-		if [ -n "$IF_BRIDGE_HW" ]; then
-			ip link set dev $port addr $IF_BRIDGE_HW
-		fi
 		ip link set dev $port master $IFACE && ip link set dev $port up
 	done
 }
@@ -68,6 +65,12 @@ del_ports() {
 		ip link set dev $port down
 		ip link set dev $port nomaster
 	done
+}
+
+set_bridge_hw() {
+	if [ -n "$IF_BRIDGE_HW" ]; then
+		ip link set dev $IFACE addr $IF_BRIDGE_HW
+	fi
 }
 
 set_bridge_opts_brctl() {
@@ -272,6 +275,7 @@ pre-up)
 		set_bridge_opts
 		set_bridge_vlans
 		add_ports
+		set_bridge_hw
 		set_bridge_port_vlans
 		wait_bridge
 


### PR DESCRIPTION
When setting the ``bridge-hw`` option the like in ...

```
auto br0
iface br0
        use bridge
        use dhcp
        bridge-hw 00:25:90:2b:30:de
        bridge-ports enp5s0f0
        bridge-fd 0
        bridge-stp off
```
... the bridge executer in the pre-up phase changed the hardware address of the bridge port, not the bridge itself:

```
ifupdown: br0: attempting to run bridge executor for phase pre-up                                                                                                                                                                             
/usr/libexec/ifupdown-ng/bridge                            
+ PORTS=enp5s0f0                                                                                                       
+ [ enp5s0f0  ]                                            
...                                                     
+ add_ports                                                
+ local port=                                              
+ [ -n 00:25:90:2b:30:de ]                                 
+ ip link set dev enp5s0f0 addr 00:25:90:2b:30:de                                                                      
+ ip link set dev enp5s0f0 master br0                                                                                  
+ ip link set dev enp5s0f0 up                              
```

This seems wrong to me, as the mac address from the master interface should get selected for the Layer2 frame. Then this option isn't really useful. Thus setting the bridges ethernet address is the better choice.