### PR TITLE
bridge: Add dev/name keyword when adding/deleting link

### DIFF
--- a/executor-scripts/linux/bridge
+++ b/executor-scripts/linux/bridge
@@ -261,7 +261,7 @@ depend)
 create)
 	# Called for the bridge interface
 	if [ "${IF_BRIDGE_PORTS}" -a ! -d "/sys/class/net/${IFACE}" ]; then
-		ip link add "${IFACE}" type bridge
+		ip link add name "${IFACE}" type bridge
 	fi
 	;;
 
@@ -296,7 +296,7 @@ post-down)
 destroy)
 	# Called for the bridge interface
 	if [ "${IF_BRIDGE_PORTS}" -a -d "/sys/class/net/${IFACE}" ]; then
-		ip link del "${IFACE}"
+		ip link del dev "${IFACE}"
 	fi
 	;;
 esac


### PR DESCRIPTION
The [ dev ] or [ name ] keywords are only optional if the interface name does not clash with keywords. An interface named "br" would cause failures.

Fixes #256