### PR TITLE
executor/ipv6-ra: set accept_ra=2 if forwarding is enabled

### DIFF
--- a/executor-scripts/linux/ipv6-ra
+++ b/executor-scripts/linux/ipv6-ra
@@ -1,6 +1,12 @@
 #!/bin/sh
 start() {
-	${MOCK} /bin/sh -c "echo 1 > /proc/sys/net/ipv6/conf/$IFACE/accept_ra"
+	forwarding=$(cat "/proc/sys/net/ipv6/conf/$IFACE/forwarding")
+
+	if [[ "$forwarding" == 1 ]]; then
+		${MOCK} /bin/sh -c "echo 2 > /proc/sys/net/ipv6/conf/$IFACE/accept_ra"
+	else
+		${MOCK} /bin/sh -c "echo 1 > /proc/sys/net/ipv6/conf/$IFACE/accept_ra"
+	fi
 }
 
 stop() {


### PR DESCRIPTION
When forwarding is enabled on an interface, Linux only accepts router advertisements when accept_ra is set to 2.