### PR TITLE
interface defaults

### DIFF
--- a/cmd/pretty-print-iface.c
+++ b/cmd/pretty-print-iface.c
@@ -28,7 +28,12 @@ prettyprint_interface_eni(struct lif_interface *iface)
 	if (iface->is_auto)
 		printf("auto %s\n", iface->ifname);
 
-	printf("%s %s\n", iface->is_template ? "template" : "iface", iface->ifname);
+	printf("%s %s", iface->is_template ? "template" : "iface", iface->ifname);
+
+	if (iface->no_defaults)
+		printf(" no-defaults");
+
+	printf("\n");
 
 	struct lif_node *iter;
 	LIF_DICT_FOREACH(iter, &iface->vars)

--- a/doc/interfaces.scd
+++ b/doc/interfaces.scd
@@ -44,7 +44,11 @@ with an address of *203.0.113.2* and gateway of *203.0.113.1*.
 	Designates that _object_ should be automatically configured
 	by the system when appropriate.
 
-*iface* _object_
+*defaults*
+	Designates default configuration settings that should be
+	added to interface and template objects when instantiated.
+
+*iface* _object_ _options_...
 	Begins a new declaration for _object_.  Any child keyword
 	associated with the declaration will be stored inside
 	_object_.
@@ -56,9 +60,18 @@ with an address of *203.0.113.2* and gateway of *203.0.113.1*.
 *source-directory* _directory_
 	Includes the files in _directory_ as configuration data.
 
-*template* _object_
+*template* _object_ _options_...
 	Begins a new declaration for _object_, like *iface*, except
 	that _object_ is defined as a *template*.
+
+# SUPPORTED OPTIONS FOR INTERFACES AND TEMPLATES
+
+Interface and template objects may take optional arguments which
+modify how they are instantiated:
+
+*no-defaults*
+	Disables processing of default settings when instantiating
+	the object.
 
 # SUPPORTED KEYWORDS FOR OBJECT TRIPLES
 

--- a/libifupdown/interface-file.c
+++ b/libifupdown/interface-file.c
@@ -268,7 +268,13 @@ static bool handle_inherit(struct lif_interface_file_parse_state *state, char *t
 static bool
 handle_iface(struct lif_interface_file_parse_state *state, char *token, char *bufp)
 {
-	char *ifname = lif_next_token(&bufp);
+	char *ifname = NULL;
+
+	if (!strcmp(token, "defaults"))
+		ifname = "defaults";
+	else
+		ifname = lif_next_token(&bufp);
+
 	if (!*ifname)
 	{
 		report_error(state, "%s without any other tokens", token);
@@ -290,9 +296,9 @@ handle_iface(struct lif_interface_file_parse_state *state, char *token, char *bu
 	}
 
 	/* mark the state->cur_iface as a template iface if `template` keyword
-	 * is used.
+	 * is used, or if the `defaults` keyword is used.
 	 */
-	if (!strcmp(token, "template"))
+	if (!strcmp(token, "template") || !strcmp(token, "defaults"))
 	{
 		state->cur_iface->is_auto = false;
 		state->cur_iface->is_template = true;
@@ -475,6 +481,7 @@ struct parser_keyword {
 static const struct parser_keyword keywords[] = {
 	{"address", handle_address},
 	{"auto", handle_auto},
+	{"defaults", handle_iface},
 	{"dhcp-hostname", handle_hostname},
 	{"gateway", handle_gateway},
 	{"hostname", handle_hostname},

--- a/libifupdown/interface-file.c
+++ b/libifupdown/interface-file.c
@@ -320,8 +320,23 @@ handle_iface(struct lif_interface_file_parse_state *state, char *token, char *bu
 			if (!handle_inherit(state, token, bufp))
 				return false;
 		}
+		else if (!strcmp(token, "no-defaults"))
+			state->cur_iface->no_defaults = true;
 
 		token = lif_next_token(&bufp);
+	}
+
+	if (!state->cur_iface->is_template && !state->cur_iface->no_defaults)
+	{
+		struct lif_interface *parent = lif_interface_collection_find(state->collection, "defaults");
+
+		if (!lif_interface_collection_inherit(state->cur_iface, parent))
+		{
+			report_error(state, "iface %s: could not inherit defaults", state->cur_iface->ifname);
+			/* Mark this interface as errornous but carry on */
+			state->cur_iface->has_config_error = true;
+			return true;
+		}
 	}
 
 	return true;

--- a/libifupdown/interface.h
+++ b/libifupdown/interface.h
@@ -51,6 +51,7 @@ struct lif_interface {
 	bool is_template;
 	bool is_pending;
 	bool is_explicit;
+	bool no_defaults;
 
 	bool has_config_error;	/* error found in interface configuration */
 


### PR DESCRIPTION
Add support for interface defaults, a special template which is inherited by all configuration objects which are not explicitly configured with the new `no-defaults` option.

This provides some syntax sugar around the new `defaults` keyword in interfaces(5).