### PR TITLE
dist: fix STATE_DIR in debian systemd unit wrapper

### DIFF
--- a/dist/debian/networking
+++ b/dist/debian/networking
@@ -6,7 +6,7 @@
 #  -- Maximilian Wilhelm <max@sdn.clinic>
 #
 
-STATE_DIR="/run/ifsate"
+STATE_DIR="/run/ifstate"
 
 # Make sure the state dir is present
 if [ ! -d "${STATE_DIR}" ]; then


### PR DESCRIPTION
This fixes a minor bug/typo in the the Debian systemd unit wrapper.