### PR TITLE
fix: allow to configure optimistic_dad in ipv6 executor

### DIFF
--- a/doc/interfaces-ipv6.scd
+++ b/doc/interfaces-ipv6.scd
@@ -34,8 +34,8 @@ the system will only respond to certain keywords by default:
 	Default: _1_
 
 *ipv6-optimistic-dad* _number_
-    Enable or disable optimistic Duplicate Address Detection.
-    Default: _0_
+	Enable or disable optimistic Duplicate Address Detection.
+	Default: _0_
 
 # EXAMPLES
 

--- a/doc/interfaces-ipv6.scd
+++ b/doc/interfaces-ipv6.scd
@@ -33,6 +33,10 @@ the system will only respond to certain keywords by default:
 	The amount of Duplicate Address Detection probes to send.
 	Default: _1_
 
+*ipv6-optimistic-dad* _number_
+    Enable or disable optimistic Duplicate Address Detection.
+    Default: _0_
+
 # EXAMPLES
 
 ```

--- a/executors/linux/ipv6
+++ b/executors/linux/ipv6
@@ -21,5 +21,9 @@ up)
 	if [ -n "$IF_IPV6_DAD_TRANSMITS" -a -e "/proc/sys/net/ipv6/conf/${IFACE}/dad_transmits" ]; then
 		${MOCK} echo ${IF_IPV6_DAD_TRANSMITS} > "/proc/sys/net/ipv6/conf/${IFACE}/dad_transmits"
 	fi
+
+	if [ -n "$IF_IPV6_OPTIMISTIC_DAD" -a -e "/proc/sys/net/ipv6/conf/${IFACE}/optimistic_dad" ]; then
+		${MOCK} echo $(yesno ${IF_IPV6_OPTIMISTIC_DAD}) > "/proc/sys/net/ipv6/conf/${IFACE}/optimistic_dad"
+	fi
 	;;
 esac


### PR DESCRIPTION
Hello there,
thank you for providing such an awesome project.

This MR adds the option for configuring `optimistic_dad` with ipv6 executor.

Kind regards,
Florian