### PR TITLE
VRRP: add executor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,7 @@ EXECUTOR_SCRIPTS_OPT ?= \
 	mpls \
 	tunnel \
 	vrf \
+	vrrp \
 	vxlan \
 	wifi \
 	wireguard \
@@ -240,6 +241,7 @@ MANPAGES_5 = \
 	doc/interfaces-ppp.5 \
 	doc/interfaces-tunnel.5 \
 	doc/interfaces-vrf.5 \
+	doc/interfaces-vrrp.5 \
 	doc/interfaces-vlan.5 \
 	doc/interfaces-vxlan.5 \
 	doc/interfaces-wifi.5 \

--- a/doc/interfaces-vrrp.scd
+++ b/doc/interfaces-vrrp.scd
@@ -1,0 +1,328 @@
+interfaces-vrrp(5)
+
+# NAME
+
+*interfaces-vrrp* - VRRP extensions for the interfaces(5) file format
+
+# DESCRIPTION
+
+VRRP stands for Virtual Router Redundancy Protocol. This protocol 
+is used to allow multiple backup routers on the same segment to take 
+over operation of each others’ IP addresses if the primary router fails. 
+This is typically used to provide fault-tolerant gateways to hosts 
+on the segment.
+
+Linux has support for MACVLAN from version *3.0*, but the _protodown_ 
+property appears only in kernel *5.1*. Don't try to use this setup for
+kernels older than *5.1*. It will not work.
+
+To be able to use VRRP you need to run an user-space software that 
+manages the Master-Backup setup. A good example is FFRouting software 
+which includes the VRRP daemon.
+
+*Note*: for each type of traffic *IPv4* or *IPv6* you need a complete different 
+interface. For one _main interface_ where you have dual-stack traffic 
+you will need 2 VRRP interfaces: one for IPv4 and one for IPv6.
+For this reason 2 addtitional interfaces are needed because each protocol 
+needs its separate MAC address for that specific traffic. That's why you 
+can't use only one VRRP interface for both IPv4 and IPv6 traffic.
+
+Convention of the name is *vrrpV-XX-YY*, where *V* stands for protocol 
+version: *4* for *IPv4* and *6* for *IPv6*, XX is the main interface index and 
+*YY* is the *VRID* (VRRP ID).
+
+This executor is backwards compatible with ifupdown2 configuration.
+
+The executor will automatically set the VRF of the VRRP interfaces 
+in case if main interface is part of a VRF.
+
+See *https://www.kernel.org/doc/html/latest/networking/ipvlan.html* or 
+*https://developers.redhat.com/blog/2018/10/22/introduction-to-linux-interfaces-for-virtual-networking#macvlan* or 
+*http://docs.frrouting.org/en/latest/vrrp.html* for more details.
+
+# VRRP-RELATED OPTIONS under main interface
+
+*vrrp* _vrid_ _array_of_addresses_
+	_vrid_  is the VRRP ID followed by a list of IP addresses in format 
+	_IP/MASK_ _IP/MASK_ .. _IP/MASK_
+	This is used to create the virtual MACVLAN 
+	interface with a specific MAC address for each VRRP instance. 
+	This should match in the FRRouting setup.++
+*Mandadory*: _yes_
+
+# EXAMPLES
+
+Configure VRRP interfaces:
+
+*R01*:
+```
+auto eth0
+iface eth0
+	address 192.168.10.2/24
+	address 192.168.11.2/24
+	address fc00:192:168:10::2/64
+	address fc00:192:168:11::2/64
+	vrrp 10 192.168.10.1 fc00:192:168:10::1
+	vrrp 20 192.168.11.1 fc00:192:168:11::1
+```
+
+*R02*:
+```
+auto eth0
+iface eth0
+	address 192.168.10.3/24
+	address 192.168.11.3/24
+	address fc00::192:168:10:3/64
+	address fc00::192:168:11:3/64
+	vrrp 10 192.168.10.1 fc00::192:168:10:1
+	vrrp 20 192.168.11.1 fc00::192:168:11:1
+```
+
+Then you have the FRRouting config:
+
+*R01*
+```
+interface eth0
+ vrrp 10 version 3
+ vrrp 10 ip 192.168.10.1
+ vrrp 10 ipv6 fc00:192:168:10::1
+ vrrp 20 version 3
+ vrrp 20 ip 192.168.11.1
+ vrrp 20 ipv6 fc00:192:168:11::1
+!
+```
+
+*R02*
+```
+interface eth0
+ vrrp 10 version 3
+ vrrp 10 priority 90
+ vrrp 10 ip 192.168.10.1
+ vrrp 10 ipv6 fc00:192:168:10::1
+ vrrp 20 version 3
+ vrrp 20 priority 90
+ vrrp 20 ip 192.168.11.1
+ vrrp 20 ipv6 fc00:192:168:11::1
+!
+```
+
+The configuration will be similar to:
+```
+R01:~# ip address show
+2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq master red state UP group default qlen 1000
+    link/ether 00:50:56:b5:d5:96 brd ff:ff:ff:ff:ff:ff
+    inet 192.168.10.2/24 scope global eth0
+       valid_lft forever preferred_lft forever
+    inet 192.168.11.2/32 scope global eth0
+       valid_lft forever preferred_lft forever
+    inet6 fc00:192:168:10::2/64 scope global tentative
+       valid_lft forever preferred_lft forever
+    inet6 fc00:192:168:11::2/64 scope global tentative
+       valid_lft forever preferred_lft forever
+85: vrrp4-2-10@eth0: <BROADCAST,MULTICAST> mtu 1500 qdisc noop master red state UP group default qlen 1000
+    link/ether 00:00:5e:00:01:0a brd ff:ff:ff:ff:ff:ff protodown on
+    inet 192.168.10.1/32 scope global vf5b9c9a2-0a-4
+       valid_lft forever preferred_lft forever
+86: vrrp6-2-10@eth0: <BROADCAST,MULTICAST> mtu 1500 qdisc noop master red state UP group default qlen 1000
+    link/ether 00:00:5e:00:02:0a brd ff:ff:ff:ff:ff:ff protodown on
+    inet6 fc00:192:168:10::1/64 scope global tentative
+       valid_lft forever preferred_lft forever
+87: vrrp4-2-20@eth0: <BROADCAST,MULTICAST> mtu 1500 qdisc noop master red state UP group default qlen 1000
+    link/ether 00:00:5e:00:01:14 brd ff:ff:ff:ff:ff:ff protodown on
+    inet 192.168.11.1/24 scope global vf5b9c9a2-14-4
+       valid_lft forever preferred_lft forever
+88: vrrp6-2-20@eth0: <BROADCAST,MULTICAST> mtu 1500 qdisc noop master red state UP group default qlen 1000
+    link/ether 00:00:5e:00:02:14 brd ff:ff:ff:ff:ff:ff protodown on
+    inet6 fc00:192:168:11::1/64 scope global tentative
+       valid_lft forever preferred_lft forever
+```
+
+Check the FRRouting configuration with:
+```
+R01# show vrrp summary
+
+ Interface   VRID   Priority   IPv4   IPv6   State (v4)   State (v6)
+ ----------------------------------------------------------------------
+ eth0        10     100         1      1      Master       Master
+ eth0        20     100         1      1      Master       Master
+
+R01# show vrrp interface eth0
+
+ Virtual Router ID                       10
+ Protocol Version                        3
+ Autoconfigured                          No
+ Shutdown                                No
+ Interface                               eth0
+ VRRP interface (v4)                     vrrp4-2-10
+ VRRP interface (v6)                     vrrp6-2-10
+ Primary IP (v4)                         192.168.10.2
+ Primary IP (v6)                         fc00:192:168:10::2
+ Virtual MAC (v4)                        00:00:5e:00:01:0a
+ Virtual MAC (v6)                        00:00:5e:00:02:0a
+ Status (v4)                             Master
+ Status (v6)                             Master
+ Priority                                100
+ Effective Priority (v4)                 100
+ Effective Priority (v6)                 100
+ Preempt Mode                            Yes
+ Accept Mode                             Yes
+ Checksum with IPv4 Pseudoheader         Yes
+ Advertisement Interval                  1000 ms
+ Master Advertisement Interval (v4) Rx   1000 ms (stale)
+ Master Advertisement Interval (v6) Rx   1000 ms (stale)
+ Advertisements Tx (v4)                  11276785
+ Advertisements Tx (v6)                  11276785
+ Advertisements Rx (v4)                  1
+ Advertisements Rx (v6)                  1
+ Gratuitous ARP Tx (v4)                  1
+ Neigh. Adverts Tx (v6)                  1
+ State transitions (v4)                  4
+ State transitions (v6)                  4
+ Skew Time (v4)                          600 ms
+ Skew Time (v6)                          600 ms
+ Master Down Interval (v4)               3600 ms
+ Master Down Interval (v6)               3600 ms
+ IPv4 Addresses                          1
+ ..................................      192.168.10.1
+ IPv6 Addresses                          1
+ ..................................      fc00:192:168:10::1
+
+
+
+ Virtual Router ID                       20
+ Protocol Version                        3
+ Autoconfigured                          No
+ Shutdown                                No
+ Interface                               eth0
+ VRRP interface (v4)                     vrrp4-2-20
+ VRRP interface (v6)                     vrrp6-2-20
+ Primary IP (v4)                         192.168.11.3
+ Primary IP (v6)                         fc00:192:168:11::3
+ Virtual MAC (v4)                        00:00:5e:00:01:14
+ Virtual MAC (v6)                        00:00:5e:00:02:14
+ Status (v4)                             Master
+ Status (v6)                             Master
+ Priority                                100
+ Effective Priority (v4)                 100
+ Effective Priority (v6)                 100
+ Preempt Mode                            Yes
+ Accept Mode                             Yes
+ Checksum with IPv4 Pseudoheader         Yes
+ Advertisement Interval                  1000 ms
+ Master Advertisement Interval (v4) Rx   1000 ms (stale)
+ Master Advertisement Interval (v6) Rx   1000 ms (stale)
+ Advertisements Tx (v4)                  11276785
+ Advertisements Tx (v6)                  11276785
+ Advertisements Rx (v4)                  1
+ Advertisements Rx (v6)                  1
+ Gratuitous ARP Tx (v4)                  1
+ Neigh. Adverts Tx (v6)                  1
+ State transitions (v4)                  4
+ State transitions (v6)                  4
+ Skew Time (v4)                          600 ms
+ Skew Time (v6)                          600 ms
+ Master Down Interval (v4)               3600 ms
+ Master Down Interval (v6)               3600 ms
+ IPv4 Addresses                          1
+ ..................................      192.168.11.1
+ IPv6 Addresses                          1
+ ..................................      fc00:192:168:11::1
+
+R02# show vrrp summary
+
+ Interface   VRID   Priority   IPv4   IPv6   State (v4)   State (v6)
+ ----------------------------------------------------------------------
+ eth0        10     100         1      1      Backup       Backup
+ eth0        20     100         1      1      Backup       Backup
+ 
+R02# show vrrp interface eth0
+
+ Virtual Router ID                       10
+ Protocol Version                        3
+ Autoconfigured                          No
+ Shutdown                                No
+ Interface                               eth0
+ VRRP interface (v4)                     vrrp4-2-10
+ VRRP interface (v6)                     vrrp6-2-10
+ Primary IP (v4)                         192.168.10.3
+ Primary IP (v6)                         fc00:192:168:10::3
+ Virtual MAC (v4)                        00:00:5e:00:01:0a
+ Virtual MAC (v6)                        00:00:5e:00:02:0a
+ Status (v4)                             Backup
+ Status (v6)                             Backup
+ Priority                                100
+ Effective Priority (v4)                 100
+ Effective Priority (v6)                 100
+ Preempt Mode                            Yes
+ Accept Mode                             Yes
+ Checksum with IPv4 Pseudoheader         Yes
+ Advertisement Interval                  1000 ms
+ Master Advertisement Interval (v4) Rx   1000 ms (stale)
+ Master Advertisement Interval (v6) Rx   1000 ms (stale)
+ Advertisements Tx (v4)                  11276785
+ Advertisements Tx (v6)                  11276785
+ Advertisements Rx (v4)                  1
+ Advertisements Rx (v6)                  1
+ Gratuitous ARP Tx (v4)                  1
+ Neigh. Adverts Tx (v6)                  1
+ State transitions (v4)                  4
+ State transitions (v6)                  4
+ Skew Time (v4)                          600 ms
+ Skew Time (v6)                          600 ms
+ Master Down Interval (v4)               3600 ms
+ Master Down Interval (v6)               3600 ms
+ IPv4 Addresses                          1
+ ..................................      192.168.10.1
+ IPv6 Addresses                          1
+ ..................................      fc00:192:168:10::1
+
+
+
+ Virtual Router ID                       20
+ Protocol Version                        3
+ Autoconfigured                          No
+ Shutdown                                No
+ Interface                               eth0
+ VRRP interface (v4)                     vrrp4-2-20
+ VRRP interface (v6)                     vrrp6-2-20
+ Primary IP (v4)                         192.168.11.2
+ Primary IP (v6)                         fc00:192:168:11::2
+ Virtual MAC (v4)                        00:00:5e:00:01:14
+ Virtual MAC (v6)                        00:00:5e:00:02:14
+ Status (v4)                             Backup
+ Status (v6)                             Backup
+ Priority                                90
+ Effective Priority (v4)                 90
+ Effective Priority (v6)                 90
+ Preempt Mode                            Yes
+ Accept Mode                             Yes
+ Checksum with IPv4 Pseudoheader         Yes
+ Advertisement Interval                  1000 ms
+ Master Advertisement Interval (v4) Rx   1000 ms (stale)
+ Master Advertisement Interval (v6) Rx   1000 ms (stale)
+ Advertisements Tx (v4)                  11276785
+ Advertisements Tx (v6)                  11276785
+ Advertisements Rx (v4)                  1
+ Advertisements Rx (v6)                  1
+ Gratuitous ARP Tx (v4)                  1
+ Neigh. Adverts Tx (v6)                  1
+ State transitions (v4)                  4
+ State transitions (v6)                  4
+ Skew Time (v4)                          600 ms
+ Skew Time (v6)                          600 ms
+ Master Down Interval (v4)               3600 ms
+ Master Down Interval (v6)               3600 ms
+ IPv4 Addresses                          1
+ ..................................      192.168.11.1
+ IPv6 Addresses                          1
+ ..................................      fc00:192:168:11
+
+```
+
+# SEE ALSO
+
+*ip-link*(8)
+
+# AUTHORS
+
+Adrian Ban (EasyNetDev) <devel@easynet.dev>

--- a/doc/interfaces.scd
+++ b/doc/interfaces.scd
@@ -151,7 +151,7 @@ the system will only respond to certain keywords by default:
 *post-up* _command_
 	Runs _command_ after bringing the interface up.
 
-Additional packages such as *bonding*, *bridge*, *tunnel*, *vrf* and
+Additional packages such as *bonding*, *bridge*, *tunnel*, *vrf*, *vrrp* and
 *vxlan* add additional keywords to this vocabulary.
 
 # EXECUTORS
@@ -201,6 +201,10 @@ most common executors are:
 *vrf*
 	The interface is a VRF.  Configuration of VRFs requires
 	the *vrf* package to be installed.
+
+*vrrp*
+	The interface has Virtual Router Redundancy Protocol configuration.
+	Configuration of VRRPs requires	the *vrrp* package to be installed.
 
 *vxlan*
 	The interface is a Virtual Extensible LAN (VXLAN) tunnel
@@ -269,6 +273,7 @@ iface eth0
 *interfaces-ppp*(5)
 *interfaces-tunnel*(5)
 *interfaces-vrf*(5)
+*interfaces-vrrp*(5)
 *interfaces-vxlan*(5)
 *interfaces-wifi*(5)
 *interfaces-wireguard*(5)

--- a/executors/linux/vrrp
+++ b/executors/linux/vrrp
@@ -1,0 +1,321 @@
+#!/bin/sh
+# This executor is responsible for setting up the Virtual Router Redundancy Protocol (VRRP) overlay interfaces.
+#
+# Copyright (C) 2026 EasyNetDev <devel@easynet.dev>
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# This software is provided 'as is' and without any warranty, express or
+# implied. In no event shall the authors be liable for any damages arising
+# from the use of this software.
+#
+# Sun, 8 Feb 2026 21:36:25 +0300
+#  -- Adrian Ban (EasyNetDev) <devel@easynet.dev>
+#
+# This executor will do the configuration for MACVLAN virtual interfaces.
+#
+# Each MACVLAN interface must be controlled by a VRRP daemon, like FRRouting.
+#
+# Options needed for VRRP executor to be able to create the MACVLAN interface are:
+#
+# IFACE                Main interface name
+# IF_VRRP_ID           VRID list to create the interfaces only
+# IF_VRRP_ADDRESS      IP list to create the interfaces and add IPs (Optional)
+#
+# Interface naming would be in format vrrpV-XX-YY
+# Where
+#  ->  V	is IP version 4 or 6
+#  ->  XX	main interface index
+#  ->  YY	VRID
+#
+# This script is written in Dash shell and is not using any Bash built-in functions.
+#
+
+[ -n "$VERBOSE" ] && set -x
+
+################################################################################
+#                        VRRP management functions                             #
+################################################################################
+
+set_IFS_newline() {
+	IFS=$(printf '\nq')
+	IFS=${IFS%q}
+}
+
+set_IFS_default() {
+	unset IFS
+}
+
+# Check address family protocol: IPv4, IPv6, or invalid
+addr_family() {
+
+	IFS='.' read -r a b c d res <<EOF
+$1
+EOF
+
+	if [ -n "$a" ] && [ -n "$b" ] && [ -n "$c" ] && [ -n "$d" ] &&
+		[ "$a" -ge 0 ] 2>/dev/null && [ "$a" -le 255 ] 2>/dev/null &&
+		[ "$b" -ge 0 ] 2>/dev/null && [ "$b" -le 255 ] 2>/dev/null &&
+		[ "$c" -ge 0 ] 2>/dev/null && [ "$c" -le 255 ] 2>/dev/null &&
+		[ "$d" -ge 0 ] 2>/dev/null && [ "$d" -le 255 ] 2>/dev/null &&
+		[ -z "$res" ]; then
+		echo 4
+		return
+	fi
+
+	if echo "$1" | grep -q ':' >/dev/null 2>&1 &&
+		! echo "$1" | grep -q '[^0-9a-fA-F:]' >/dev/null 2>&1; then
+		echo 6
+		return
+	fi
+
+	echo 0
+
+	return
+}
+
+# Verify the VRRP ID if has correct values: between 1 and 255
+is_vrid() {
+	if [ -z "$(echo $1 | sed 's/\([0-9]\{1,3\}\)\(.*\)/\2/g')" ]; then
+		if [ $1 -gt 0 -a $1 -le 255 ]; then
+			return 0
+		else
+			return 1
+		fi
+	else
+		# Could be IPv4 or IPv6 address
+		return 2
+	fi
+}
+
+check_vrrp() {
+	# If we don't have vrrp then exit.
+	if [ -z "${IFACE}" ]; then
+		exit 0
+	fi
+
+	# If we don't have vrrp then exit.
+	if [ -z "${IF_VRRP_CFG}" ]; then
+		exit 0
+	fi
+
+	if [ -z "${MOCK}" -a ! -d /sys/class/net/${IFACE} ]; then
+		echo "Main interface $IFACE doesn't exist!"
+		exit 0
+	fi
+
+	if [ -n "${MOCK}" ]; then
+		IFINDEX=1
+	else
+		IFINDEX=$(cat /sys/class/net/${IFACE}/ifindex)
+	fi
+
+	# Work around Dash shell newline issues.
+	# Strings with multi-lines using \n are not processed correctly.
+	# This is valid for kyua tests where there is an export using multi-line string.
+	IF_VRRP_CFG=$(echo "$IF_VRRP_CFG")
+}
+
+add_vrrp_addr4() {
+	local IFACE_VRRP="$1"
+	local ADDR="$2"
+	local PREFIX="$3"
+	if [ $(addr_family "${ADDR}") -eq 4 ]; then
+		if [ "${PREFIX}" = "${ADDR}" ]; then
+			PREFIX=32
+		elif [ ${PREFIX} -lt 1 -o ${PREFIX} -gt 32 ]; then
+			PREFIX=32
+		fi
+		# Add IP address to the VRRP interface.
+		${MOCK} ip address add ${ADDR}/${PREFIX} dev ${IFACE_VRRP}
+	fi
+}
+
+add_vrrp_addr6() {
+	local IFACE_VRRP=ifupdown-ng-git/executors/linux/vrrp"$1"
+	local ADDR="$2"
+	local PREFIX="$3"
+	if [ $(addr_family "${ADDR}") -eq 6 ]; then
+		if [ "${PREFIX}" = "${ADDR}" ]; then
+			PREFIX=128
+		elif [ "${PREFIX}" -lt 1 -o "${PREFIX}" -gt 128 ]; then
+			PREFIX=128
+		fi
+		# Add IP address to the VRRP interface.
+		${MOCK} ip -6 address add ${ADDR}/${PREFIX} dev ${IFACE_VRRP}
+	fi
+}
+
+# Compute the MAC address the VRRP interface
+get_vrrp_mac() {
+	VRRP_MAC_6="00:00:5e:00:02:"$(printf "%02x\n" $1)
+	VRRP_MAC_4="00:00:5e:00:01:"$(printf "%02x\n" $1)
+}
+
+vrrp_gen_name() {
+	local VRID="$1"
+	local IFINDEX="$2"
+	# Using main interface index and VRID we will generate an interface for VRRP
+	IFACE_VRRP_4="vrrp4-${IFINDEX}-${VRID}"
+	IFACE_VRRP_6="vrrp6-${IFINDEX}-${VRID}"
+}
+
+case "$PHASE" in
+depend)
+	# There is no dependency because is used directly under interface.
+	exit 0
+	;;
+create)
+	check_vrrp
+
+	# ${MOCK} variable is used by test tools to printout the setup. We need to skip some tests if ${MOCK} is used.
+	# Check if main interface vrrp-raw-device exists in system. If not then skip.
+	if [ -z "${MOCK}" -a ! -d /sys/class/net/${IFACE} ]; then
+		echo "Main interface $IFACE doesn't exist!"
+		exit 0
+	fi
+
+	# The format of the IF_VRRP_CFG is <VRRP_ID> <IP> ..
+	# It can be multiple times for each VRID
+	# We check if first read in the list is the VRRP_ID
+	set_IFS_newline
+	for VRRP in ${IF_VRRP_CFG}; do
+		VRID=$(echo $VRRP | cut -f1 -d" ")
+
+		if ! is_vrid $VRID; then
+			echo "VRID $VRID is invalid! VRRP ID must have values between 1 and 255!"
+			continue
+		fi
+
+		# Compute VRRP interfaces name
+		vrrp_gen_name "${VRID}" "${IFINDEX}"
+
+		# Check if the VRRP interface itself exists. If yes then skip.
+		if [ -z "${MOCK}" -a -d /sys/class/net/"${IFACE_VRRP_4}" ]; then
+			echo "Interface ${IFACE_VRRP_4} already exist. Please check your system."
+			continue
+		fi
+		if [ -z "${MOCK}" -a -d /sys/class/net/"${IFACE_VRRP_6}" ]; then
+			echo "Interface ${IFACE_VRRP_6} already exist. Please check your system."
+			continue
+		fi
+
+		VRRP_MAC_4=""
+		VRRP_MAC_6=""
+
+		get_vrrp_mac $VRID
+
+		# Get the VRF for the vrrp-raw-device. VRRP interface MUST be in the same VRF as the vrrp-raw-device is.
+		if [ -z "${MOCK}" ]; then
+			VRRP_VRF=$(ifquery -p vrf-member ${IFACE} | head -1)
+		fi
+
+		# Create MACVLAN interfaces for VRRP IPv4
+		${MOCK} ip link add link ${IFACE} name ${IFACE_VRRP_4} type macvlan mode bridge
+		${MOCK} ip link set dev ${IFACE_VRRP_4} address ${VRRP_MAC_4}
+		# In case of boot, we must set protodown to on until FRRouting will takeover the control of the interface
+		${MOCK} ip link set dev ${IFACE_VRRP_4} protodown on
+		${MOCK} ip link set dev ${IFACE_VRRP_4} up
+		### Always disable IPv6 on VRRP IPv4 interface
+		if [ -z "${MOCK}" ]; then
+			echo 1 >/proc/sys/net/ipv6/conf/${IFACE_VRRP_4}/disable_ipv6
+		fi
+		# Create MACVLAN interfaces for VRRP IPv6
+		${MOCK} ip link add link ${IFACE} name ${IFACE_VRRP_6} type macvlan mode bridge
+		${MOCK} ip link set dev ${IFACE_VRRP_6} addrgenmode random
+		${MOCK} ip link set dev ${IFACE_VRRP_6} address ${VRRP_MAC_6}
+		# In case of OS booting, we must set protodown to on until FRRouting will takeover the control of the interface
+		${MOCK} ip link set dev ${IFACE_VRRP_6} protodown on
+		${MOCK} ip link set dev ${IFACE_VRRP_6} up
+
+		# In case we have VRF, add VRRP interfaces under VRF
+		if [ -n "${VRRP_VRF}" ]; then
+			${MOCK} ip link set ${IFACE_VRRP_4} master $VRRP_VRF
+			${MOCK} ip link set ${IFACE_VRRP_6} master $VRRP_VRF
+		fi
+	done
+
+	exit 0
+	;;
+pre-up)
+	check_vrrp
+
+	# Add VRRP Virtual IPs to VRRP interfaces
+	VRRP_ID=0
+
+	# The format of the IF_VRRP_CFG is <VRRP_ID> <IP> ..
+	# It will be multiple times for each VRID
+	# We check if first read in the list is the VRRP_ID
+
+	set_IFS_newline
+	for VRRP in ${IF_VRRP_CFG}; do
+
+		VRID=$(echo $VRRP | cut -f1 -d" ")
+		VRRP_IPS=$(echo $VRRP | cut -f2- -d" ")
+
+		set_IFS_default
+		for VRRP_IP in ${VRRP_IPS}; do
+			# This should by an IPv4 or IPv6 address
+			# Check if we have VRRP_ID in a previously step. Maybe somehow an invalid VRRP ID escape from checks
+			if ! is_vrid $VRID; then
+				echo "Invalid VRRP ID: $VRRP_ID"
+				VRID=0
+				continue
+			fi
+
+			if [ $(addr_family ${VRRP_IP}) -eq 0 ]; then
+				echo "IP address ${VRRP_IP} is invalid. Skip it."
+				continue
+			else
+				# Compute VRRP interfaces name
+				vrrp_gen_name "${VRID}" "${IFINDEX}"
+
+				# Get address and prefix
+				VRRP_IP_ADDR=$(echo ${VRRP_IP} | cut -f1 -d"/")
+				VRRP_PREFIX=$(echo ${VRRP_IP} | cut -f2 -d"/")
+				add_vrrp_addr4 "${IFACE_VRRP_4}" "${VRRP_IP_ADDR}" "${VRRP_PREFIX}"
+				add_vrrp_addr6 "${IFACE_VRRP_6}" "${VRRP_IP_ADDR}" "${VRRP_PREFIX}"
+			fi
+		done
+		set_IFS_newline
+	done
+	;;
+
+post-up) ;;
+pre-down)
+	check_vrrp
+
+	#IFACE_CRC32=$(compute_crc32_hex ${IFACE})
+
+	if [ -z "${MOCK}" -a ! -d "/sys/class/net/${IFACE}/" ]; then
+		exit 0
+	fi
+	if [ -z "${MOCK}" ]; then
+		VRRP_IFACES=$(find /sys/class/net/${IFACE}/ -name "upper_vrrp*" -printf "%f\n" | sed "s/upper_//g")
+	else
+		# Let's generate list of the interfaces for MOCK. In test mode, these interfaces doesn't exist in system.
+		VRRP_IFACES=""
+		for VRRP_ID in ${IF_VRRP_ID}; do
+			if ! is_vrid $VRRP_ID; then
+				continue
+			fi
+			# Compute VRRP interfaces name
+			vrrp_gen_name "${VRID}" "${IFINDEX}"
+
+			VRRP_IFACES="$VRRP_IFACES "${IFACE_VRRP_4}" "${IFACE_VRRP_6}
+		done
+	fi
+
+	# VRRP interfaces should be destroied in post-down, becase if you have a bond, bridge or teaming interfaces, these are destroied in "destroy" stage.
+	for VRRP_IFACE in ${VRRP_IFACES}; do
+		if [ -z "${MOCK}" -a -d "/sys/class/net/${VRRP_IFACE}" ] || [ -n ${MOCK} ]; then
+			${MOCK} ip link del ${VRRP_IFACE} type macvlan
+		fi
+	done
+	;;
+destroy) ;;
+esac
+
+exit 0

--- a/tests/linux/Kyuafile
+++ b/tests/linux/Kyuafile
@@ -16,5 +16,6 @@ atf_test_program{name='ppp_test'}
 atf_test_program{name='static_test'}
 atf_test_program{name='tunnel_test'}
 atf_test_program{name='vrf_test'}
+atf_test_program{name='vrrp_test'}
 atf_test_program{name='vxlan_test'}
 atf_test_program{name='wireguard_test'}


### PR DESCRIPTION
Hello,

Please find my VRRP executor 

 * Add VRRP executor for ifupdown-ng
 * Simple format: vrrp VRID IP1 IP2 ..
 * Simple VRRP interface format: vrrpV-XX-YY
 * Where V is the protocol version, XX is the interface index and YY is VRID.
 * Backwards compatible with ifupdown2